### PR TITLE
Added the ability to use ip instead of fs-id when DNS isn't available

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ To mount over TLS automatically, add an `/etc/fstab` entry like:
 file-system-id efs-mount-point efs _netdev,tls 0 0
 ```
 
+For cases where DNS isn't enabled, use an IP address in-place of file-system-id
+
+```
+$ sudo mount -t efs 1.2.3.4 efs-mount-point/
+```
+
 For more information on mounting with the mount helper, see the [documentation](https://docs.aws.amazon.com/efs/latest/ug/using-amazon-efs-utils.html).
 
 #### amazon-efs-mount-watchdog

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -65,7 +65,9 @@ LOG_FILE = 'mount.log'
 
 STATE_FILE_DIR = '/var/run/efs'
 
-FS_NAME_RE = re.compile('^(?P<fs_id>fs-[0-9a-f]+)(?::(?P<path>/.*))?$')
+ip_pattern = '^(?:[0-9]{1,3}\.){3}[0-9]{1,3}'
+IP_RE = re.compile(ip_pattern)
+FS_NAME_RE = re.compile('^(?P<fs_id>(fs-[0-9a-f]+|' + ip_pattern + '))(?::(?P<path>/.*))?$')
 
 INSTANCE_METADATA_SERVICE_URL = 'http://169.254.169.254/latest/dynamic/instance-identity/document/'
 
@@ -499,6 +501,9 @@ def get_dns_name(config, fs_id):
     def _validate_replacement_field_count(format_str, expected_ct):
         if format_str.count('{') != expected_ct or format_str.count('}') != expected_ct:
             raise ValueError('DNS name format has an incorrect number of replacement fields')
+
+    if IP_RE.match(fs_id):  # Don't attempt to resolve raw IP
+        return fs_id
 
     dns_name_format = config.get(CONFIG_SECTION, 'dns_name_format')
 

--- a/test/mount_efs_test/test_get_dns_name.py
+++ b/test/mount_efs_test/test_get_dns_name.py
@@ -96,3 +96,11 @@ def test_get_dns_name_unresolvable(mocker, capsys):
 
     out, err = capsys.readouterr()
     assert 'Failed to resolve' in err
+
+def test_get_dns_name_ip_address(mocker):
+    ip_addr = '10.1.2.3'
+
+    config = _get_mock_config()
+
+    dns_name = mount_efs.get_dns_name(config, ip_addr)
+    assert dns_name == ip_addr

--- a/test/mount_efs_test/test_parse_arguments.py
+++ b/test/mount_efs_test/test_parse_arguments.py
@@ -94,3 +94,19 @@ def test_parse_arguments():
     assert '/home' == path
     assert '/dir' == mountpoint
     assert {'foo': None, 'bar': 'baz', 'quux': None} == options
+
+def test_parse_arguments_ip_default_path(capsys):
+    fsid, path, mountpoint, options = mount_efs.parse_arguments(['mount', '10.1.2.3', '/dir'])
+
+    assert '10.1.2.3' == fsid
+    assert '/' == path
+    assert '/dir' == mountpoint
+    assert {} == options
+
+def test_parse_arguments_ip_custom_path(capsys):
+    fsid, path, mountpoint, options = mount_efs.parse_arguments(['mount', '10.1.2.3:/home', '/dir'])
+
+    assert '10.1.2.3' == fsid
+    assert '/home' == path
+    assert '/dir' == mountpoint
+    assert {} == options


### PR DESCRIPTION
*Issue #, if available:* 
#1 

*Description of changes:*
I've changed the handling of the fs-id to not attempt DNS resolution if an IP address is passed instead. This was done in a way that the call syntax of the mount utility is similar when using an fs-id or an ip address, and allows ip address users to have essentially the same syntax as if they were mounting a traditional NFS volume.

Ex: `sudo mount -t efs 1.2.3.4 efs-mount-point/`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.