### PR TITLE
Allow a CNAME DNS-name in addition to the EFS ID

### DIFF
--- a/build-deb.sh
+++ b/build-deb.sh
@@ -11,7 +11,7 @@ set -ex
 
 BASE_DIR=$(pwd)
 BUILD_ROOT=${BASE_DIR}/build/debbuild
-VERSION=1.3
+VERSION=1.4
 
 echo 'Cleaning deb build workspace'
 rm -rf ${BUILD_ROOT}

--- a/dist/amazon-efs-utils.control
+++ b/dist/amazon-efs-utils.control
@@ -1,6 +1,6 @@
 Package: amazon-efs-utils
 Architecture: all
-Version: 1.3
+Version: 1.4
 Section: utils
 Depends: python|python2, nfs-common, stunnel4 (>= 4.56)
 Priority: optional

--- a/dist/amazon-efs-utils.spec
+++ b/dist/amazon-efs-utils.spec
@@ -20,7 +20,7 @@
 %endif
 
 Name      : amazon-efs-utils
-Version   : 1.3
+Version   : 1.4
 Release   : 1%{?dist}
 Summary   : This package provides utilities for simplifying the use of EFS file systems
 

--- a/man/mount.efs.8
+++ b/man/mount.efs.8
@@ -12,15 +12,12 @@ package, which simplifies using EFS file systems\&.
 \fBmount\&.efs\fR is meant to be used through the \
 \fBmount\fR(8) command for mounting EFS file systems\&.
 .sp
-\fIfs-id-or-dns-name\fR has to be of any of the following \
-three forms:
+\fIfs-id-or-dns-name\fR has to be of one of the following \
+two forms:
 .P
 .IP \(bu
 An EFS filesystem ID in the form of "fs\-abcd1234", generated \
 when the file system is created\&.
-.IP \(bu
-A fully-qualified EFS DNS name in the form of \
-"fs\-abcd1234\&.efs\&.us-east-1\&.amazonaws\&.com"\&.
 .IP \(bu
 A domain name that has a resolvable DNS-CNAME record, \
 which in turn points to a fully-qualified EFS DNS name \
@@ -100,18 +97,20 @@ sudo mount -t efs -o tls,verify=0 fs-abcd1234 /mnt/efs
 Mount an EFS file system with file system ID "fs-abcd1234" at mount point \
 "/mnt/efs" using encryption of data in transit and a verify level of 0\&.
 .TP
-sudo mount -t efs fs-abcd1234.efs.us-east-1.amazonaws.com /mnt/efs
-Mount an EFS file system with the fully-qualified EFS DNS name \
-"fs\-abcd1234\&.efs\&.us-east-1\&.amazonaws\&.com" at mount point \
-"/mnt/efs" without encryption of data in transit\&. If the region \
-is correct, this is identical to mounting with just the file system ID\&.
-.TP
 sudo mount -t efs custom-cname.example.com /mnt/efs
 Mount an EFS file system using the custom DNS name \
 "custom-cname\&.example\&.com" \(em which has to \
 resolve to a fully-qualified EFS DNS name such as \
 "fs\-abcd1234\&.efs\&.us-east-1\&.amazonaws\&.com" \
 \(em at mount point "/mnt/efs" without encryption \
+of data in transit\&.
+.TP
+sudo mount -t efs -o tls custom-cname.example.com /mnt/efs
+Mount an EFS file system using the custom DNS name \
+"custom-cname\&.example\&.com" \(em which has to \
+resolve to a fully-qualified EFS DNS name such as \
+"fs\-abcd1234\&.efs\&.us-east-1\&.amazonaws\&.com" \
+\(em at mount point "/mnt/efs" using encryption \
 of data in transit\&.
 .SH "FILES"
 .TP

--- a/man/mount.efs.8
+++ b/man/mount.efs.8
@@ -3,7 +3,7 @@
 \fBmount\&.efs\fR \- Mount helper for using Amazon EFS file systems\&.
 .SH "SYNOPSIS"
 .sp
-\fBmount\&.efs\fR \fIfile\-system\-id\fR \fImount-point\fR [\fB\-o\fR \fIoptions\fR]
+\fBmount\&.efs\fR \fIfs-id-or-dns-name\fR \fImount-point\fR [\fB\-o\fR \fIoptions\fR]
 .SH "DESCRIPTION"
 .sp
 \fBmount\&.efs\fR is part of the \fBamazon\-efs\-utils\fR \
@@ -12,9 +12,21 @@ package, which simplifies using EFS file systems\&.
 \fBmount\&.efs\fR is meant to be used through the \
 \fBmount\fR(8) command for mounting EFS file systems\&.
 .sp
-\fIfile\-system\-id\fR is an EFS file system ID in the \
-form of "fs\-abcd1234", generated when the file system \
-is created\&. \fImount-point\fR is the local directory \
+\fIfs-id-or-dns-name\fR has to be of any of the following \
+three forms:
+.P
+.IP \(bu
+An EFS filesystem ID in the form of "fs\-abcd1234", generated \
+when the file system is created\&.
+.IP \(bu
+A fully-qualified EFS DNS name in the form of \
+"fs\-abcd1234\&.efs\&.us-east-1\&.amazonaws\&.com"\&.
+.IP \(bu
+A domain name that has a resolvable DNS-CNAME record, \
+which in turn points to a fully-qualified EFS DNS name \
+in the form of "fs\-abcd1234\&.efs\&.us-east-1\&.amazonaws\&.com"\&.
+.P
+\fImount-point\fR is the local directory \
 on which the file system will be mounted\&.
 .sp
 \fBmount\&.efs\fR automatically applies the following NFS options:
@@ -87,6 +99,20 @@ Mount an EFS file system with file system ID "fs-abcd1234" at mount point \
 sudo mount -t efs -o tls,verify=0 fs-abcd1234 /mnt/efs
 Mount an EFS file system with file system ID "fs-abcd1234" at mount point \
 "/mnt/efs" using encryption of data in transit and a verify level of 0\&.
+.TP
+sudo mount -t efs fs-abcd1234.efs.us-east-1.amazonaws.com /mnt/efs
+Mount an EFS file system with the fully-qualified EFS DNS name \
+"fs\-abcd1234\&.efs\&.us-east-1\&.amazonaws\&.com" at mount point \
+"/mnt/efs" without encryption of data in transit\&. If the region \
+is correct, this is identical to mounting with just the file system ID\&.
+.TP
+sudo mount -t efs custom-cname.example.com /mnt/efs
+Mount an EFS file system using the custom DNS name \
+"custom-cname\&.example\&.com" \(em which has to \
+resolve to a fully-qualified EFS DNS name such as \
+"fs\-abcd1234\&.efs\&.us-east-1\&.amazonaws\&.com" \
+\(em at mount point "/mnt/efs" without encryption \
+of data in transit\&.
 .SH "FILES"
 .TP
 \fI/sbin/mount.efs\fR

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -54,7 +54,7 @@ except ImportError:
     from urllib.error import URLError
     from urllib.request import urlopen
 
-VERSION = '1.3'
+VERSION = '1.4'
 
 CONFIG_FILE = '/etc/amazon/efs/efs-utils.conf'
 CONFIG_SECTION = 'mount'

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -613,8 +613,8 @@ def match_device(config, device):
                 return fs_id, path
     else:
         fatal_error('The specified CNAME "%s" did not resolve to a valid DNS name for an EFS mount target. '
-                    'Please refer to the EFS documentation for mounting with DNS names for examples: '
-                    'https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.' % remote)
+                    'Please refer to the EFS documentation for mounting with DNS names for examples: %s'
+                    % (remote, 'https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html'))
 
 
 def mount_tls(config, init_system, dns_name, path, fs_id, mountpoint, options):

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -608,6 +608,7 @@ def match_device(config, device):
             fs_id = efs_fqdn_match.group('fs_id')
             expected_dns_name = get_dns_name(config, fs_id)
 
+            # check that the DNS name of the mount target matches exactly the DNS name the CNAME resolves to
             if hostname == expected_dns_name:
                 return fs_id, path
     else:

--- a/src/watchdog/__init__.py
+++ b/src/watchdog/__init__.py
@@ -25,7 +25,7 @@ try:
 except ImportError:
     from configparser import ConfigParser
 
-VERSION = '1.3'
+VERSION = '1.4'
 
 CONFIG_FILE = '/etc/amazon/efs/efs-utils.conf'
 CONFIG_SECTION = 'mount-watchdog'

--- a/test/mount_efs_test/test_match_device.py
+++ b/test/mount_efs_test/test_match_device.py
@@ -17,12 +17,6 @@ CORRECT_DEVICE_DESCRIPTORS_FS_ID = [
     ('fs-deadbeef:/some/subpath', ('fs-deadbeef', '/some/subpath')),
     ('fs-deadbeef:/some/subpath/with:colons', ('fs-deadbeef', '/some/subpath/with:colons')),
 ]
-CORRECT_DEVICE_DESCRIPTORS_EFS_FQDN = [
-    ('fs-deadbeef.efs.us-east-1.amazonaws.com', ('fs-deadbeef', '/')),
-    ('fs-deadbeef.efs.us-east-1.amazonaws.com:/', ('fs-deadbeef', '/')),
-    ('fs-deadbeef.efs.us-east-1.amazonaws.com:/some/subpath', ('fs-deadbeef', '/some/subpath')),
-    ('fs-deadbeef.efs.us-east-1.amazonaws.com:/some/subpath/with:colons', ('fs-deadbeef', '/some/subpath/with:colons')),
-]
 CORRECT_DEVICE_DESCRIPTORS_CNAME_DNS = [
     ('custom-cname.example.com', ('fs-deadbeef', '/')),
     ('custom-cname.example.com:/', ('fs-deadbeef', '/')),
@@ -34,13 +28,6 @@ CORRECT_DEVICE_DESCRIPTORS_CNAME_DNS = [
 def test_match_device_correct_descriptors_fs_id(mocker):
     for device, (fs_id, path) in CORRECT_DEVICE_DESCRIPTORS_FS_ID:
         assert (fs_id, path) == mount_efs.match_device(None, device)
-
-
-def test_match_device_correct_descriptors_efs_fqdn(mocker):
-    get_dns_name_mock = mocker.patch('mount_efs.get_dns_name', return_value='fs-deadbeef.efs.us-east-1.amazonaws.com')
-    for device, (fs_id, path) in CORRECT_DEVICE_DESCRIPTORS_EFS_FQDN:
-        assert (fs_id, path) == mount_efs.match_device(None, device)
-    get_dns_name_mock.assert_called()
 
 
 def test_match_device_correct_descriptors_cname_dns_primary(mocker):
@@ -87,18 +74,6 @@ def test_match_device_correct_descriptors_cname_dns_amongst_invalid(mocker):
     gethostbyname_ex_mock.assert_called()
 
 
-def test_match_device_wrong_efs_dns_name(mocker, capsys):
-    get_dns_name_mock = mocker.patch('mount_efs.get_dns_name', return_value='fs-deadbeef.efs.us-west-1.amazonaws.com')
-    with pytest.raises(SystemExit) as ex:
-        mount_efs.match_device(None, 'fs-deadbeef.efs.us-east-1.amazonaws.com:/')
-
-    assert 0 != ex.value.code
-    out, err = capsys.readouterr()
-    assert 'Fully qualified EFS domain name specified' in err
-    assert 'didn\'t match the expected value' in err
-    get_dns_name_mock.assert_called()
-
-
 def test_match_device_unresolvable_domain(mocker, capsys):
     mocker.patch('socket.gethostbyname_ex', side_effect=socket.gaierror)
     with pytest.raises(SystemExit) as ex:
@@ -117,7 +92,7 @@ def test_match_device_no_hostnames(mocker, capsys):
 
     assert 0 != ex.value.code
     out, err = capsys.readouterr()
-    assert 'returned no entries' in err
+    assert 'did not resolve to an EFS mount target' in err
     gethostbyname_ex_mock.assert_called()
 
 
@@ -129,7 +104,7 @@ def test_match_device_no_hostnames2(mocker, capsys):
 
     assert 0 != ex.value.code
     out, err = capsys.readouterr()
-    assert 'returned no entries' in err
+    assert 'did not resolve to an EFS mount target' in err
     gethostbyname_ex_mock.assert_called()
 
 
@@ -141,7 +116,7 @@ def test_match_device_resolve_to_invalid_efs_dns_name(mocker, capsys):
 
     assert 0 != ex.value.code
     out, err = capsys.readouterr()
-    assert 'resolved to no valid/expected EFS DNS name' in err
+    assert 'did not resolve to a valid DNS name' in err
     gethostbyname_ex_mock.assert_called()
 
 
@@ -154,6 +129,6 @@ def test_match_device_resolve_to_unexpected_efs_dns_name(mocker, capsys):
 
     assert 0 != ex.value.code
     out, err = capsys.readouterr()
-    assert 'resolved to no valid/expected EFS DNS name' in err
+    assert 'did not resolve to a valid DNS name' in err
     get_dns_name_mock.assert_called()
     gethostbyname_ex_mock.assert_called()

--- a/test/mount_efs_test/test_match_device.py
+++ b/test/mount_efs_test/test_match_device.py
@@ -1,0 +1,159 @@
+#
+# Copyright 2017-2018 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the MIT License. See the LICENSE accompanying this file
+# for the specific language governing permissions and limitations under
+# the License.
+#
+import socket
+
+import pytest
+
+import mount_efs
+
+CORRECT_DEVICE_DESCRIPTORS_FS_ID = [
+    ('fs-deadbeef', ('fs-deadbeef', '/')),
+    ('fs-deadbeef:/', ('fs-deadbeef', '/')),
+    ('fs-deadbeef:/some/subpath', ('fs-deadbeef', '/some/subpath')),
+    ('fs-deadbeef:/some/subpath/with:colons', ('fs-deadbeef', '/some/subpath/with:colons')),
+]
+CORRECT_DEVICE_DESCRIPTORS_EFS_FQDN = [
+    ('fs-deadbeef.efs.us-east-1.amazonaws.com', ('fs-deadbeef', '/')),
+    ('fs-deadbeef.efs.us-east-1.amazonaws.com:/', ('fs-deadbeef', '/')),
+    ('fs-deadbeef.efs.us-east-1.amazonaws.com:/some/subpath', ('fs-deadbeef', '/some/subpath')),
+    ('fs-deadbeef.efs.us-east-1.amazonaws.com:/some/subpath/with:colons', ('fs-deadbeef', '/some/subpath/with:colons')),
+]
+CORRECT_DEVICE_DESCRIPTORS_CNAME_DNS = [
+    ('custom-cname.example.com', ('fs-deadbeef', '/')),
+    ('custom-cname.example.com:/', ('fs-deadbeef', '/')),
+    ('custom-cname.example.com:/some/subpath', ('fs-deadbeef', '/some/subpath')),
+    ('custom-cname.example.com:/some/subpath/with:colons', ('fs-deadbeef', '/some/subpath/with:colons')),
+]
+
+
+def test_match_device_correct_descriptors_fs_id(mocker):
+    for device, (fs_id, path) in CORRECT_DEVICE_DESCRIPTORS_FS_ID:
+        assert (fs_id, path) == mount_efs.match_device(None, device)
+
+
+def test_match_device_correct_descriptors_efs_fqdn(mocker):
+    get_dns_name_mock = mocker.patch('mount_efs.get_dns_name', return_value='fs-deadbeef.efs.us-east-1.amazonaws.com')
+    for device, (fs_id, path) in CORRECT_DEVICE_DESCRIPTORS_EFS_FQDN:
+        assert (fs_id, path) == mount_efs.match_device(None, device)
+    get_dns_name_mock.assert_called()
+
+
+def test_match_device_correct_descriptors_cname_dns_primary(mocker):
+    get_dns_name_mock = mocker.patch('mount_efs.get_dns_name', return_value='fs-deadbeef.efs.us-east-1.amazonaws.com')
+    gethostbyname_ex_mock = mocker.patch('socket.gethostbyname_ex',
+                                         return_value=('fs-deadbeef.efs.us-east-1.amazonaws.com', [], None))
+    for device, (fs_id, path) in CORRECT_DEVICE_DESCRIPTORS_CNAME_DNS:
+        assert (fs_id, path) == mount_efs.match_device(None, device)
+    get_dns_name_mock.assert_called()
+    gethostbyname_ex_mock.assert_called()
+
+
+def test_match_device_correct_descriptors_cname_dns_secondary(mocker):
+    get_dns_name_mock = mocker.patch('mount_efs.get_dns_name', return_value='fs-deadbeef.efs.us-east-1.amazonaws.com')
+    gethostbyname_ex_mock = mocker.patch('socket.gethostbyname_ex',
+                                         return_value=(None, ['fs-deadbeef.efs.us-east-1.amazonaws.com'], None))
+    for device, (fs_id, path) in CORRECT_DEVICE_DESCRIPTORS_CNAME_DNS:
+        assert (fs_id, path) == mount_efs.match_device(None, device)
+    get_dns_name_mock.assert_called()
+    gethostbyname_ex_mock.assert_called()
+
+
+def test_match_device_correct_descriptors_cname_dns_tertiary(mocker):
+    get_dns_name_mock = mocker.patch('mount_efs.get_dns_name', return_value='fs-deadbeef.efs.us-east-1.amazonaws.com')
+    gethostbyname_ex_mock = mocker.patch('socket.gethostbyname_ex',
+                                         return_value=(None, [None, 'fs-deadbeef.efs.us-east-1.amazonaws.com'], None))
+    for device, (fs_id, path) in CORRECT_DEVICE_DESCRIPTORS_CNAME_DNS:
+        assert (fs_id, path) == mount_efs.match_device(None, device)
+    get_dns_name_mock.assert_called()
+    gethostbyname_ex_mock.assert_called()
+
+
+def test_match_device_correct_descriptors_cname_dns_amongst_invalid(mocker):
+    get_dns_name_mock = mocker.patch('mount_efs.get_dns_name', return_value='fs-deadbeef.efs.us-east-1.amazonaws.com')
+    gethostbyname_ex_mock = mocker.patch(
+        'socket.gethostbyname_ex',
+        return_value=('fs-deadbeef.efs.us-west-1.amazonaws.com',
+                      ['fs-deadbeef.efs.us-east-1.amazonaws.com', 'invalid-efs-name.example.com'],
+                      None)
+    )
+    for device, (fs_id, path) in CORRECT_DEVICE_DESCRIPTORS_CNAME_DNS:
+        assert (fs_id, path) == mount_efs.match_device(None, device)
+    get_dns_name_mock.assert_called()
+    gethostbyname_ex_mock.assert_called()
+
+
+def test_match_device_wrong_efs_dns_name(mocker, capsys):
+    get_dns_name_mock = mocker.patch('mount_efs.get_dns_name', return_value='fs-deadbeef.efs.us-west-1.amazonaws.com')
+    with pytest.raises(SystemExit) as ex:
+        mount_efs.match_device(None, 'fs-deadbeef.efs.us-east-1.amazonaws.com:/')
+
+    assert 0 != ex.value.code
+    out, err = capsys.readouterr()
+    assert 'Fully qualified EFS domain name specified' in err
+    assert 'didn\'t match the expected value' in err
+    get_dns_name_mock.assert_called()
+
+
+def test_match_device_unresolvable_domain(mocker, capsys):
+    mocker.patch('socket.gethostbyname_ex', side_effect=socket.gaierror)
+    with pytest.raises(SystemExit) as ex:
+        mount_efs.match_device(None, 'custom-cname.example.com')
+
+    assert 0 != ex.value.code
+    out, err = capsys.readouterr()
+    assert 'Failed to resolve' in err
+
+
+def test_match_device_no_hostnames(mocker, capsys):
+    gethostbyname_ex_mock = mocker.patch('socket.gethostbyname_ex',
+                                         return_value=(None, [], None))
+    with pytest.raises(SystemExit) as ex:
+        mount_efs.match_device(None, 'custom-cname.example.com')
+
+    assert 0 != ex.value.code
+    out, err = capsys.readouterr()
+    assert 'returned no entries' in err
+    gethostbyname_ex_mock.assert_called()
+
+
+def test_match_device_no_hostnames2(mocker, capsys):
+    gethostbyname_ex_mock = mocker.patch('socket.gethostbyname_ex',
+                                         return_value=(None, [None, None], None))
+    with pytest.raises(SystemExit) as ex:
+        mount_efs.match_device(None, 'custom-cname.example.com')
+
+    assert 0 != ex.value.code
+    out, err = capsys.readouterr()
+    assert 'returned no entries' in err
+    gethostbyname_ex_mock.assert_called()
+
+
+def test_match_device_resolve_to_invalid_efs_dns_name(mocker, capsys):
+    gethostbyname_ex_mock = mocker.patch('socket.gethostbyname_ex',
+                                         return_value=('invalid-efs-name.example.com', [], None))
+    with pytest.raises(SystemExit) as ex:
+        mount_efs.match_device(None, 'custom-cname.example.com')
+
+    assert 0 != ex.value.code
+    out, err = capsys.readouterr()
+    assert 'resolved to no valid/expected EFS DNS name' in err
+    gethostbyname_ex_mock.assert_called()
+
+
+def test_match_device_resolve_to_unexpected_efs_dns_name(mocker, capsys):
+    get_dns_name_mock = mocker.patch('mount_efs.get_dns_name', return_value='fs-deadbeef.efs.us-west-1.amazonaws.com')
+    gethostbyname_ex_mock = mocker.patch('socket.gethostbyname_ex',
+                                         return_value=('fs-deadbeef.efs.us-east-1.amazonaws.com', [], None))
+    with pytest.raises(SystemExit) as ex:
+        mount_efs.match_device(None, 'custom-cname.example.com')
+
+    assert 0 != ex.value.code
+    out, err = capsys.readouterr()
+    assert 'resolved to no valid/expected EFS DNS name' in err
+    get_dns_name_mock.assert_called()
+    gethostbyname_ex_mock.assert_called()

--- a/test/mount_efs_test/test_parse_arguments.py
+++ b/test/mount_efs_test/test_parse_arguments.py
@@ -13,7 +13,7 @@ import pytest
 
 def _test_parse_arguments_help(capsys, help):
     with pytest.raises(SystemExit) as ex:
-        mount_efs.parse_arguments(['mount', 'foo', 'bar', help])
+        mount_efs.parse_arguments(None, ['mount', 'foo', 'bar', help])
 
     assert 0 == ex.value.code
 
@@ -31,7 +31,7 @@ def test_parse_arguments_help_short(capsys):
 
 def test_parse_arguments_version(capsys):
     with pytest.raises(SystemExit) as ex:
-        mount_efs.parse_arguments(['mount', 'foo', 'bar', '--version'])
+        mount_efs.parse_arguments(None, ['mount', 'foo', 'bar', '--version'])
 
     assert 0 == ex.value.code
 
@@ -41,7 +41,7 @@ def test_parse_arguments_version(capsys):
 
 def test_parse_arguments_no_fs_id(capsys):
     with pytest.raises(SystemExit) as ex:
-        mount_efs.parse_arguments(['mount'])
+        mount_efs.parse_arguments(None, ['mount'])
 
     assert 0 != ex.value.code
 
@@ -51,7 +51,7 @@ def test_parse_arguments_no_fs_id(capsys):
 
 def test_parse_arguments_no_mount_point(capsys):
     with pytest.raises(SystemExit) as ex:
-        mount_efs.parse_arguments(['mount', 'fs-deadbeef'])
+        mount_efs.parse_arguments(None, ['mount', 'fs-deadbeef'])
 
     assert 0 != ex.value.code
 
@@ -59,18 +59,8 @@ def test_parse_arguments_no_mount_point(capsys):
     assert 'Usage:' in err
 
 
-def test_parse_arguments_invalid_fs_id(capsys):
-    with pytest.raises(SystemExit) as ex:
-        mount_efs.parse_arguments(['mount', 'not-a-file-system-id', '/dir'])
-
-    assert 0 != ex.value.code
-
-    out, err = capsys.readouterr()
-    assert 'Invalid file system name' in err
-
-
 def test_parse_arguments_default_path():
-    fsid, path, mountpoint, options = mount_efs.parse_arguments(['mount', 'fs-deadbeef', '/dir'])
+    fsid, path, mountpoint, options = mount_efs.parse_arguments(None, ['mount', 'fs-deadbeef', '/dir'])
 
     assert 'fs-deadbeef' == fsid
     assert '/' == path
@@ -79,7 +69,7 @@ def test_parse_arguments_default_path():
 
 
 def test_parse_arguments_custom_path():
-    fsid, path, mountpoint, options = mount_efs.parse_arguments(['mount', 'fs-deadbeef:/home', '/dir'])
+    fsid, path, mountpoint, options = mount_efs.parse_arguments(None, ['mount', 'fs-deadbeef:/home', '/dir'])
 
     assert 'fs-deadbeef' == fsid
     assert '/home' == path
@@ -88,7 +78,7 @@ def test_parse_arguments_custom_path():
 
 
 def test_parse_arguments():
-    fsid, path, mountpoint, options = mount_efs.parse_arguments(['mount', 'fs-deadbeef:/home', '/dir', '-o', 'foo,bar=baz,quux'])
+    fsid, path, mountpoint, options = mount_efs.parse_arguments(None, ['mount', 'fs-deadbeef:/home', '/dir', '-o', 'foo,bar=baz,quux'])
 
     assert 'fs-deadbeef' == fsid
     assert '/home' == path


### PR DESCRIPTION
## Issue \#

* #9

## Description of changes

This change introduces additional logic which allows the user to specify either a fully-qualified EFS DNS name, or a custom DNS name that resolves to a fully-qualified EFS DNS name via a CNAME record.

The EFS DNS name will then be compared to the EFS name we would have expected for the given EFS ID. If it doesn't match, we'll show the user a readable error message for this to aid in troubleshooting.

Once the EFS DNS name has been verified, the rest of the logic is untouched. This means that this change only impacts the parameter logic at the very start and does not touch anything of the already tested, more critical logic.

Important: the usage and internal logic to mount by EFS ID is unchanged, making this change fully backwards compatible.

## License agreement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
