### PR TITLE
Wait for Network

### DIFF
--- a/dist/amazon-efs-mount-watchdog.service
+++ b/dist/amazon-efs-mount-watchdog.service
@@ -8,6 +8,7 @@
 
 [Unit]
 Description=amazon-efs-mount-watchdog
+After=remote-fs.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
The watchdog daemon should wait for the network to be up

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
