### PR TITLE
fix for additional unexpected arguments

### DIFF
--- a/build-deb.sh
+++ b/build-deb.sh
@@ -11,7 +11,7 @@ set -ex
 
 BASE_DIR=$(pwd)
 BUILD_ROOT=${BASE_DIR}/build/debbuild
-VERSION=1.5
+VERSION=1.6
 
 echo 'Cleaning deb build workspace'
 rm -rf ${BUILD_ROOT}

--- a/dist/amazon-efs-utils.control
+++ b/dist/amazon-efs-utils.control
@@ -1,6 +1,6 @@
 Package: amazon-efs-utils
 Architecture: all
-Version: 1.5
+Version: 1.6
 Section: utils
 Depends: python|python2, nfs-common, stunnel4 (>= 4.56)
 Priority: optional

--- a/dist/amazon-efs-utils.spec
+++ b/dist/amazon-efs-utils.spec
@@ -20,7 +20,7 @@
 %endif
 
 Name      : amazon-efs-utils
-Version   : 1.5
+Version   : 1.6
 Release   : 1%{?dist}
 Summary   : This package provides utilities for simplifying the use of EFS file systems
 

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -54,7 +54,7 @@ except ImportError:
     from urllib.error import URLError
     from urllib.request import urlopen
 
-VERSION = '1.5'
+VERSION = '1.6'
 
 CONFIG_FILE = '/etc/amazon/efs/efs-utils.conf'
 CONFIG_SECTION = 'mount'
@@ -499,8 +499,9 @@ def parse_arguments(config, args=None):
         fsname = args[1]
     if len(args) > 2:
         mountpoint = args[2]
-    if len(args) > 4 and args[3] == '-o':
-        options = parse_options(args[4])
+    if len(args) > 4 and '-o' in args[:-1]:
+        options_index = args.index('-o') + 1
+        options = parse_options(args[options_index])
 
     if not fsname or not mountpoint:
         usage(out=sys.stderr)

--- a/src/watchdog/__init__.py
+++ b/src/watchdog/__init__.py
@@ -25,7 +25,7 @@ try:
 except ImportError:
     from configparser import ConfigParser
 
-VERSION = '1.5'
+VERSION = '1.6'
 
 CONFIG_FILE = '/etc/amazon/efs/efs-utils.conf'
 CONFIG_SECTION = 'mount-watchdog'

--- a/test/mount_efs_test/test_parse_arguments.py
+++ b/test/mount_efs_test/test_parse_arguments.py
@@ -77,6 +77,16 @@ def test_parse_arguments_custom_path():
     assert {} == options
 
 
+def test_parse_arguments_verbose():
+    fsid, path, mountpoint, options = mount_efs.parse_arguments(None,
+                                                                ['mount', 'fs-deadbeef:/home', '/dir', '-v', '-o', 'foo,bar=baz,quux'])
+
+    assert 'fs-deadbeef' == fsid
+    assert '/home' == path
+    assert '/dir' == mountpoint
+    assert {'foo': None, 'bar': 'baz', 'quux': None} == options
+
+
 def test_parse_arguments():
     fsid, path, mountpoint, options = mount_efs.parse_arguments(None,
                                                                 ['mount', 'fs-deadbeef:/home', '/dir', '-o', 'foo,bar=baz,quux'])


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/efs-utils/issues/19

*Description of changes:*
looks for `'-o'` in `args` instead of assuming position.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.