### PR TITLE
- Support Python 3.2+

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ The `efs-utils` package has been verified against the following Linux distributi
 | RHEL 7 | `rpm`| `systemd` |
 | Debian 9 | `deb` | `systemd` |
 | Ubuntu 16.04 | `deb` | `systemd` |
+| SLES 12 | rpm | `systemd` |
+| SLES 15 | rpm | `systemd` |
+| openSUSE Leap 42.x | rpm | `systemd` |
+| openSUSE Leap 15.x | rpm | `systemd` |
+
 
 ## Prerequisites
 
@@ -30,9 +35,17 @@ For those using Amazon Linux or Amazon Linux 2, the easiest way to install `efs-
 $ sudo yum -y install amazon-efs-utils
 ```
 
+### On SUSE Linux distributions
+
+```
+$ zypper in aws-efs-utils
+```
+
+Package availability depends on the repository configuration
+
 ### On other Linux distributions
 
-Other distributions require building the package from source and installing it.
+Installing he package from source:
 
 - Clone this repository:
 

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -44,9 +44,9 @@ from contextlib import contextmanager
 from logging.handlers import RotatingFileHandler
 
 try:
-    import ConfigParser
+    import ConfigParser as cp
 except ImportError:
-    from configparser import ConfigParser
+    import configparser as cp
 
 try:
     from urllib2 import urlopen, URLError
@@ -517,7 +517,7 @@ def assert_root():
 
 
 def read_config(config_file=CONFIG_FILE):
-    p = ConfigParser.SafeConfigParser()
+    p = cp.ConfigParser()
     p.read(config_file)
     return p
 

--- a/src/watchdog/__init__.py
+++ b/src/watchdog/__init__.py
@@ -21,9 +21,9 @@ from logging.handlers import RotatingFileHandler
 from signal import SIGTERM
 
 try:
-    import ConfigParser
+    import ConfigParser as cp
 except ImportError:
-    from configparser import ConfigParser
+    import configparser as cp
 
 VERSION = '1.5'
 
@@ -275,7 +275,7 @@ def assert_root():
 
 
 def read_config(config_file=CONFIG_FILE):
-    p = ConfigParser.SafeConfigParser()
+    p = cp.ConfigParser()
     p.read(config_file)
     return p
 

--- a/test/mount_efs_test/test_choose_tls_port.py
+++ b/test/mount_efs_test/test_choose_tls_port.py
@@ -7,8 +7,12 @@
 #
 
 import mount_efs
-import ConfigParser
 import socket
+
+try:
+    import ConfigParser as cp
+except ImportError:
+    import configparser as cp
 
 import pytest
 
@@ -19,7 +23,7 @@ DEFAULT_TLS_PORT_RANGE_HIGH = 20449
 
 
 def _get_config():
-    config = ConfigParser.SafeConfigParser()
+    config = cp.ConfigParser()
     config.add_section(mount_efs.CONFIG_SECTION)
     config.set(mount_efs.CONFIG_SECTION, 'port_range_lower_bound', str(DEFAULT_TLS_PORT_RANGE_LOW))
     config.set(mount_efs.CONFIG_SECTION, 'port_range_upper_bound', str(DEFAULT_TLS_PORT_RANGE_HIGH))

--- a/test/mount_efs_test/test_write_stunnel_config_file.py
+++ b/test/mount_efs_test/test_write_stunnel_config_file.py
@@ -7,8 +7,12 @@
 #
 
 import mount_efs
-import ConfigParser
 import os
+
+try:
+    import ConfigParser as cp
+except ImportError:
+    import configparser as cp
 
 import pytest
 
@@ -32,7 +36,7 @@ def _get_config(mocker, stunnel_debug_enabled=False, stunnel_check_cert_hostname
     if stunnel_check_cert_validity is None:
         stunnel_check_cert_validity = stunnel_check_cert_validity_supported
 
-    config = ConfigParser.SafeConfigParser()
+    config = cp.ConfigParser()
     config.add_section(mount_efs.CONFIG_SECTION)
     config.set(mount_efs.CONFIG_SECTION, 'stunnel_debug_enabled', str(stunnel_debug_enabled))
     config.set(mount_efs.CONFIG_SECTION, 'stunnel_check_cert_hostname', str(stunnel_check_cert_hostname))


### PR DESCRIPTION

*Issue #24

*Description of changes:*
- SafeConfigParser has been dropped in Python versions greater than 3.2 swicth to using ConfigParser
- Add SUSE distros as tested to README

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
