### PR TITLE
EFS mount helper to mount with IP address

### DIFF
--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -282,12 +282,6 @@ def write_stunnel_config_file(config, state_file_dir, fs_id, mountpoint, tls_por
             efs_config['checkHost'] = dns_name
         else:
             fatal_error(tls_controls_message % 'stunnel_check_cert_hostname')
-    
-    if config.getboolean(CONFIG_SECTION, 'stunnel_check_cert_hostname') and IP_RE.match(fs_id):
-        if check_host_supported:
-            efs_config['checkIP'] = dns_name
-        else:
-            fatal_error(tls_controls_message % 'stunnel_check_cert_hostname')
 
     if config.getboolean(CONFIG_SECTION, 'stunnel_check_cert_validity'):
         if ocsp_aia_supported:

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -65,6 +65,7 @@ LOG_FILE = 'mount.log'
 STATE_FILE_DIR = '/var/run/efs'
 
 FS_ID_RE = re.compile('^(?P<fs_id>fs-[0-9a-f]+)$')
+IP_RE = re.compile("^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
 EFS_FQDN_RE = re.compile('^(?P<fs_id>fs-[0-9a-f]+)\.efs\.(?P<region>[a-z0-9-]+)\.amazonaws.com$')
 
 INSTANCE_METADATA_SERVICE_URL = 'http://169.254.169.254/latest/dynamic/instance-identity/document/'
@@ -276,11 +277,6 @@ def write_stunnel_config_file(config, state_file_dir, fs_id, mountpoint, tls_por
         'or disable "%%s" in %s.\nSee %s for more detail.' % (CONFIG_FILE,
                                                               'https://docs.aws.amazon.com/console/efs/troubleshooting-tls')
 
-    if config.getboolean(CONFIG_SECTION, 'stunnel_check_cert_hostname'):
-        if check_host_supported:
-            efs_config['checkHost'] = dns_name
-        else:
-            fatal_error(tls_controls_message % 'stunnel_check_cert_hostname')
 
     if config.getboolean(CONFIG_SECTION, 'stunnel_check_cert_validity'):
         if ocsp_aia_supported:
@@ -503,7 +499,27 @@ def parse_arguments_early_exit(args=None):
     if '--version' in args[1:]:
         sys.stdout.write('%s Version: %s\n' % (args[0], VERSION))
         sys.exit(0)
+def parse_arguments1(config, args=None):
+    """Parse arguments, return (fsid, path, mountpoint, options)"""
+    if args is None:
+        args = sys.argv
 
+    fsname = None
+    mountpoint = None
+    options = {}
+
+    if len(args) > 1:
+        fsname = args[1]
+    if len(args) > 2:
+        mountpoint = args[2]
+    if len(args) > 4 and '-o' in args[:-1]:
+        options_index = args.index('-o') + 1
+        options = parse_options(args[options_index])
+
+    if not fsname or not mountpoint:
+        usage(out=sys.stderr)
+
+    return mountpoint, options
 
 def parse_arguments(config, args=None):
     """Parse arguments, return (fsid, path, mountpoint, options)"""
@@ -613,8 +629,11 @@ def match_device(config, device):
         path = '/'
 
     if FS_ID_RE.match(remote):
-        return remote, path
-
+    	return remote, path
+    
+    if IP_RE.match(remote):
+	return remote, path
+   
     try:
         primary, secondaries, _ = socket.gethostbyname_ex(remote)
         hostnames = filter(lambda e: e is not None, [primary] + secondaries)
@@ -645,7 +664,7 @@ def match_device(config, device):
                     'Please refer to the EFS documentation for mounting with DNS names for examples: %s'
                     % (remote, 'https://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html'))
 
-
+    
 def mount_tls(config, init_system, dns_name, path, fs_id, mountpoint, options):
     with bootstrap_tls(config, init_system, dns_name, fs_id, mountpoint, options) as tunnel_proc:
         mount_completed = threading.Event()
@@ -673,17 +692,30 @@ def main():
 
     config = read_config()
     bootstrap_logging(config)
-
+    #device = sys.argv[3]
+    #try:
+	#remote, path = device.split(':',1)
+    #except ValueError:
+	#remote = device
+	#path = '/'
+    #print(remote) 	
+    #if socket.inet_aton(remote):
+    	 #dns_name = remote 
+    
+    	 #mountpoint, options = parse_arguments1(config)
+	 #fs_id =  dns_name
+    #else:
     fs_id, path, mountpoint, options = parse_arguments(config)
+
+
+    dns_name = fs_id
+    print(dns_name)
 
     logging.info('version=%s options=%s', VERSION, options)
     check_unsupported_options(options)
 
     init_system = get_init_system()
     check_network_status(fs_id, init_system)
-
-    dns_name = get_dns_name(config, fs_id)
-
     if 'tls' in options:
         mount_tls(config, init_system, dns_name, path, fs_id, mountpoint, options)
     else:

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -65,7 +65,7 @@ LOG_FILE = 'mount.log'
 STATE_FILE_DIR = '/var/run/efs'
 
 FS_ID_RE = re.compile('^(?P<fs_id>fs-[0-9a-f]+)$')
-IP_RE = re.compile("^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
+IP_RE = re.compile("^([01]?[0-9]{1,2}|2[0-4][0-9]|25[0-5])\.([01]?[0-9]{1,2}|2[0-4][0-9]|25[0-5])\.([01]?[0-9]{1,2}|2[0-4][0-9]|25[0-5])\.([01]?[0-9]{1,2}|2[0-4][0-9]|25[0-5])$")
 EFS_FQDN_RE = re.compile('^(?P<fs_id>fs-[0-9a-f]+)\.efs\.(?P<region>[a-z0-9-]+)\.amazonaws.com$')
 
 INSTANCE_METADATA_SERVICE_URL = 'http://169.254.169.254/latest/dynamic/instance-identity/document/'

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -276,7 +276,12 @@ def write_stunnel_config_file(config, state_file_dir, fs_id, mountpoint, tls_por
     tls_controls_message = 'WARNING: Your client lacks sufficient controls to properly enforce TLS. Please upgrade stunnel, ' \
         'or disable "%%s" in %s.\nSee %s for more detail.' % (CONFIG_FILE,
                                                               'https://docs.aws.amazon.com/console/efs/troubleshooting-tls')
-
+    
+    if config.getboolean(CONFIG_SECTION, 'stunnel_check_cert_hostname') and FS_ID_RE.match(fs_id):
+        if check_host_supported:
+            efs_config['checkHost'] = dns_name
+        else:
+            fatal_error(tls_controls_message % 'stunnel_check_cert_hostname')
 
     if config.getboolean(CONFIG_SECTION, 'stunnel_check_cert_validity'):
         if ocsp_aia_supported:
@@ -690,7 +695,6 @@ def main():
 	
     else:
 	   dns_name = fs_id
-    	   print(dns_name)
 	
     if 'tls' in options:
         mount_tls(config, init_system, dns_name, path, fs_id, mountpoint, options)

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -282,6 +282,12 @@ def write_stunnel_config_file(config, state_file_dir, fs_id, mountpoint, tls_por
             efs_config['checkHost'] = dns_name
         else:
             fatal_error(tls_controls_message % 'stunnel_check_cert_hostname')
+    
+    if config.getboolean(CONFIG_SECTION, 'stunnel_check_cert_hostname') and IP_RE.match(fs_id):
+        if check_host_supported:
+            efs_config['checkIP'] = dns_name
+        else:
+            fatal_error(tls_controls_message % 'stunnel_check_cert_hostname')
 
     if config.getboolean(CONFIG_SECTION, 'stunnel_check_cert_validity'):
         if ocsp_aia_supported:

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -499,27 +499,6 @@ def parse_arguments_early_exit(args=None):
     if '--version' in args[1:]:
         sys.stdout.write('%s Version: %s\n' % (args[0], VERSION))
         sys.exit(0)
-def parse_arguments1(config, args=None):
-    """Parse arguments, return (fsid, path, mountpoint, options)"""
-    if args is None:
-        args = sys.argv
-
-    fsname = None
-    mountpoint = None
-    options = {}
-
-    if len(args) > 1:
-        fsname = args[1]
-    if len(args) > 2:
-        mountpoint = args[2]
-    if len(args) > 4 and '-o' in args[:-1]:
-        options_index = args.index('-o') + 1
-        options = parse_options(args[options_index])
-
-    if not fsname or not mountpoint:
-        usage(out=sys.stderr)
-
-    return mountpoint, options
 
 def parse_arguments(config, args=None):
     """Parse arguments, return (fsid, path, mountpoint, options)"""
@@ -692,30 +671,21 @@ def main():
 
     config = read_config()
     bootstrap_logging(config)
-    #device = sys.argv[3]
-    #try:
-	#remote, path = device.split(':',1)
-    #except ValueError:
-	#remote = device
-	#path = '/'
-    #print(remote) 	
-    #if socket.inet_aton(remote):
-    	 #dns_name = remote 
-    
-    	 #mountpoint, options = parse_arguments1(config)
-	 #fs_id =  dns_name
-    #else:
     fs_id, path, mountpoint, options = parse_arguments(config)
-
-
-    dns_name = fs_id
-    print(dns_name)
 
     logging.info('version=%s options=%s', VERSION, options)
     check_unsupported_options(options)
 
     init_system = get_init_system()
     check_network_status(fs_id, init_system)
+	
+    if FS_ID_RE.match(fs_id):
+	   dns_name = get_dns_name(config, fs_id)
+	
+    else:
+	   dns_name = fs_id
+    	   print(dns_name)
+	
     if 'tls' in options:
         mount_tls(config, init_system, dns_name, path, fs_id, mountpoint, options)
     else:

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -484,7 +484,7 @@ def mount_nfs(dns_name, path, mountpoint, options):
 
 
 def usage(out, exit_code=1):
-    out.write('Usage: mount.efs [--version] [-h|--help] <fsname> <mountpoint> [-o <options>]\n')
+    out.write('Usage: mount.efs [--version] [-h|--help] <fsname|mount-target IP> <mountpoint> [-o <options>]\n')
     sys.exit(exit_code)
 
 
@@ -610,8 +610,14 @@ def match_device(config, device):
     if FS_ID_RE.match(remote):
     	return remote, path
     
-    if IP_RE.match(remote):
+    ip_address = IP_RE.match(remote)
+
+    if ip_address:
 	return remote, path
+    else :
+	 fatal_error(
+            'The specified IP "%s" is invalid' % remote
+        )	
    
     try:
         primary, secondaries, _ = socket.gethostbyname_ex(remote)


### PR DESCRIPTION
I have made changes to allow mounting of EFS with IP address.
I have added a regex to validate the IP address format. Once the arguments are parsed and the regex matches for IP address, IP address is used to mount the EFS. And when tls option is selected, the stunnel configuration is created without the "CheckHost" feild.