### PR TITLE
filename of .deb-package should include architecture

### DIFF
--- a/build-deb.sh
+++ b/build-deb.sh
@@ -74,7 +74,7 @@ tar czf data.tar.gz etc sbin usr var --owner=0 --group=0
 cd ${BASE_DIR}
 
 echo 'Building deb'
-DEB=${BUILD_ROOT}/amazon-efs-utils-${VERSION}-${RELEASE}.deb
+DEB=${BUILD_ROOT}/amazon-efs-utils-${VERSION}-${RELEASE}_all.deb
 ar r ${DEB} ${BUILD_ROOT}/debian-binary
 ar r ${DEB} ${BUILD_ROOT}/control.tar.gz
 ar r ${DEB} ${BUILD_ROOT}/data.tar.gz


### PR DESCRIPTION
The filename of a Debian-package (.deb) should/must include the supported architecture:
For more info see - https://www.debian.org/doc/manuals/debian-faq/ch-pkg_basics.en.html

*Change to small for an issue, IMHO.*

*Description of changes:*
in the buildscript for the debian-package (build-deb.sh) line 64 now includes the choosen
architecture, with which the package will be build, thats all.
For more info see - https://www.debian.org/doc/manuals/debian-faq/ch-pkg_basics.en.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
