### PR TITLE
Specify python2 in shebangs

### DIFF
--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright 2017-2018 Amazon.com, Inc. and its affiliates. All Rights Reserved.
 #

--- a/src/watchdog/__init__.py
+++ b/src/watchdog/__init__.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 # Copyright 2017-2018 Amazon.com, Inc. and its affiliates. All Rights Reserved.
 #


### PR DESCRIPTION
*Description of changes:*

On Fedora31, at least, the command make rpm fails with the following output in stderr:
```
+ /usr/lib/rpm/redhat/brp-mangle-shebangs
*** ERROR: ambiguous python shebang in /usr/bin/amazon-efs-mount-watchdog: #!/usr/bin/env python. Change it to python3 (or python2) explicitly.
*** ERROR: ambiguous python shebang in /sbin/mount.efs: #!/usr/bin/env python. Change it to python3 (or python2) explicitly.
error: Bad exit status from /var/tmp/rpm-tmp.2YLA4h (%install)
    bogus date in %changelog: Tue Mar 02 2020 Yuan Gao <ygaochn@amazon.com> - 1.23-2
    Bad exit status from /var/tmp/rpm-tmp.2YLA4h (%install)
gmake: *** [Makefile:57: rpm-only] Error 1
```

It seems that the `/usr/lib/rpm/redhat/brp-mangle-shebang` tool is erroring out because the shebangs are not in accordance with [PEP-0394](https://www.python.org/dev/peps/pep-0394).  I'm looking specifically at the next to last bullet [here](https://www.python.org/dev/peps/pep-0394/#id23).

In this pull request I simply change the shebangs that are failing from `#!/usr/bin/env python` to `#!/usr/bin/env python2`.  This gets rid of the error when running `make rpm` in Fedora31, but more importantly it ensures that the correct version of python is used when running the code.  On many of the latest distribution releases, `/usr/bin/env python` points to a python3 executable.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
