### PR TITLE
Add line to specfile to leave shebangs alone for python scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,9 @@ specfile: clean
 .PHONY: sources
 sources: tarball specfile
 
-.PHONY: rhel8-support
-rhel8-support:
-	./rhel8-support.sh
+.PHONY: shebang-support
+shebang-support:
+	./mangle-shebangs.sh
 
 .PHONY: rpm-only
 rpm-only:
@@ -58,7 +58,7 @@ rpm-only:
 	cp $(BUILD_DIR)/RPMS/*/*rpm build
 
 .PHONY: rpm
-rpm: rhel8-support sources rpm-only
+rpm: shebang-support sources rpm-only
 
 .PHONY: deb
 deb:

--- a/mangle-shebangs.sh
+++ b/mangle-shebangs.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+SYSTEM_RELEASE_PATH=/etc/system-release
+RHEL8_REGEX="Red Hat Enterprise Linux release 8"
+FEDORA_REGEX="Fedora release"
+
+# RHEL8 and Fedora30+ both treat shebangs of the form "#!/usr/bin/env python" as errors
+if [ -f $SYSTEM_RELEASE_PATH ] && [[ "$(cat $SYSTEM_RELEASE_PATH)" =~ $RHEL8_REGEX|$FEDORA_REGEX ]]; then
+    # Replace the first line in .py to "#!/usr/bin/env python2" no
+    # matter what it was before
+    sed -i -e '1 s/^.*$/\#!\/usr\/bin\/env python2/' src/watchdog/__init__.py
+    sed -i -e '1 s/^.*$/\#!\/usr\/bin\/env python2/' src/mount_efs/__init__.py
+fi

--- a/rhel8-support.sh
+++ b/rhel8-support.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-SYSTEM_RELEASE_PATH=/etc/system-release
-
-if [ -f $SYSTEM_RELEASE_PATH ] && [[ "$(cat $SYSTEM_RELEASE_PATH)" =~ "Red Hat Enterprise Linux release 8" ]]; then
-    # Replace the first line in .py to "#!/usr/bin/env python2" no matter what it was before
-    sed -i -e '1 s/^.*$/\#!\/usr\/bin\/env python2/' src/watchdog/__init__.py
-    sed -i -e '1 s/^.*$/\#!\/usr\/bin\/env python2/' src/mount_efs/__init__.py
-fi


### PR DESCRIPTION
*Description of changes:*

On Fedora31, at least, the command `make rpm` fails with the following output in stderr:
```
+ /usr/lib/rpm/redhat/brp-mangle-shebangs
*** ERROR: ambiguous python shebang in /usr/bin/amazon-efs-mount-watchdog: #!/usr/bin/env python. Change it to python3 (or python2) explicitly.
*** ERROR: ambiguous python shebang in /sbin/mount.efs: #!/usr/bin/env python. Change it to python3 (or python2) explicitly.
error: Bad exit status from /var/tmp/rpm-tmp.2YLA4h (%install)
    bogus date in %changelog: Tue Mar 02 2020 Yuan Gao <ygaochn@amazon.com> - 1.23-2
    Bad exit status from /var/tmp/rpm-tmp.2YLA4h (%install)
gmake: *** [Makefile:57: rpm-only] Error 1
```

It seems that the `/usr/lib/rpm/redhat/brp-mangle-shebang` tool is erroring out because Fedora wants packagers to choose python2 or python3.  [PEP-0394](https://www.python.org/dev/peps/pep-0394), on the other hand, allows one to use a shebang of that form if the code supports both python2 and python3.

This code supports both versions of python, so in this pull request I exclude the python scripts from the shebang check.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
