### PR TITLE
add CentOS 8 to mangle-shebangs.sh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,9 @@ workflows:
           name: centos7
           image: centos:centos7
       - build-rpm-package:
+          name: centos8
+          image: centos:centos8
+      - build-rpm-package:
           name: amazon-linux-2
           image: amazonlinux:2
       - build-rpm-package:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ The `efs-utils` package has been verified against the following Linux distributi
 | Amazon Linux 2017.09 | `rpm` | `upstart` |
 | Amazon Linux 2 | `rpm` | `systemd` |
 | CentOS 7 | `rpm` | `systemd` |
-| CentOS 8 | `rpm` | `systemd` |
 | RHEL 7 | `rpm`| `systemd` |
 | RHEL 8 | `rpm`| `systemd` |
 | Debian 9 | `deb` | `systemd` |
@@ -133,7 +132,7 @@ or refer to the [documentation](https://docs.aws.amazon.com/efs/latest/ug/using-
 
 ## Upgrading stunnel for RHEL/CentOS
 
-By default, when using the EFS mount helper with TLS, it enforces certificate hostname checking. The EFS mount helper uses the `stunnel` program for its TLS functionality. Please note that some versions of Linux do not include a version of `stunnel` that supports TLS features by default. When using such a Linux version, mounting an EFS file system using TLS will fail.
+By default, when using the EFS mount helper with TLS, it enforces certificate hostname checking. The EFS mount helper uses the `stunnel` program for its TLS functionality. Please note that some versions of Linux do not include a version of `stunnel` that supports TLS features by default. When using such a Linux version, mounting an EFS file system using TLS will fail. 
 
 Once you’ve installed the `amazon-efs-utils` package, to upgrade your system’s version of `stunnel`, see [Upgrading Stunnel](https://docs.aws.amazon.com/efs/latest/ug/using-amazon-efs-utils.html#upgrading-stunnel).
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The `efs-utils` package has been verified against the following Linux distributi
 | Amazon Linux 2017.09 | `rpm` | `upstart` |
 | Amazon Linux 2 | `rpm` | `systemd` |
 | CentOS 7 | `rpm` | `systemd` |
+| CentOS 8 | `rpm` | `systemd` |
 | RHEL 7 | `rpm`| `systemd` |
 | RHEL 8 | `rpm`| `systemd` |
 | Debian 9 | `deb` | `systemd` |
@@ -132,7 +133,7 @@ or refer to the [documentation](https://docs.aws.amazon.com/efs/latest/ug/using-
 
 ## Upgrading stunnel for RHEL/CentOS
 
-By default, when using the EFS mount helper with TLS, it enforces certificate hostname checking. The EFS mount helper uses the `stunnel` program for its TLS functionality. Please note that some versions of Linux do not include a version of `stunnel` that supports TLS features by default. When using such a Linux version, mounting an EFS file system using TLS will fail. 
+By default, when using the EFS mount helper with TLS, it enforces certificate hostname checking. The EFS mount helper uses the `stunnel` program for its TLS functionality. Please note that some versions of Linux do not include a version of `stunnel` that supports TLS features by default. When using such a Linux version, mounting an EFS file system using TLS will fail.
 
 Once you’ve installed the `amazon-efs-utils` package, to upgrade your system’s version of `stunnel`, see [Upgrading Stunnel](https://docs.aws.amazon.com/efs/latest/ug/using-amazon-efs-utils.html#upgrading-stunnel).
 

--- a/mangle-shebangs.sh
+++ b/mangle-shebangs.sh
@@ -3,9 +3,10 @@
 SYSTEM_RELEASE_PATH=/etc/system-release
 RHEL8_REGEX="Red Hat Enterprise Linux release 8"
 FEDORA_REGEX="Fedora release"
+CENTOS8_REGEX="CentOS Linux release 8"
 
 # RHEL8 and Fedora30+ both treat shebangs of the form "#!/usr/bin/env python" as errors
-if [ -f $SYSTEM_RELEASE_PATH ] && [[ "$(cat $SYSTEM_RELEASE_PATH)" =~ $RHEL8_REGEX|$FEDORA_REGEX ]]; then
+if [ -f $SYSTEM_RELEASE_PATH ] && [[ "$(cat $SYSTEM_RELEASE_PATH)" =~ $RHEL8_REGEX|$FEDORA_REGEX|$CENTOS8_REGEX ]]; then
     # Replace the first line in .py to "#!/usr/bin/env python2" no
     # matter what it was before
     sed -i -e '1 s/^.*$/\#!\/usr\/bin\/env python2/' src/watchdog/__init__.py

--- a/mangle-shebangs.sh
+++ b/mangle-shebangs.sh
@@ -5,7 +5,7 @@ RHEL8_REGEX="Red Hat Enterprise Linux release 8"
 FEDORA_REGEX="Fedora release"
 CENTOS8_REGEX="CentOS Linux release 8"
 
-# RHEL8 and Fedora30+ both treat shebangs of the form "#!/usr/bin/env python" as errors
+# RHEL8, Fedora30+ and CentOS 8 treat shebangs of the form "#!/usr/bin/env python" as errors
 if [ -f $SYSTEM_RELEASE_PATH ] && [[ "$(cat $SYSTEM_RELEASE_PATH)" =~ $RHEL8_REGEX|$FEDORA_REGEX|$CENTOS8_REGEX ]]; then
     # Replace the first line in .py to "#!/usr/bin/env python2" no
     # matter what it was before

--- a/mangle-shebangs.sh
+++ b/mangle-shebangs.sh
@@ -5,7 +5,7 @@ RHEL8_REGEX="Red Hat Enterprise Linux release 8"
 FEDORA_REGEX="Fedora release"
 CENTOS8_REGEX="CentOS Linux release 8"
 
-# RHEL8, Fedora30+ and CentOS 8 treat shebangs of the form "#!/usr/bin/env python" as errors
+# RHEL8, Fedora30+ and CentOS8 treat shebangs of the form "#!/usr/bin/env python" as errors
 if [ -f $SYSTEM_RELEASE_PATH ] && [[ "$(cat $SYSTEM_RELEASE_PATH)" =~ $RHEL8_REGEX|$FEDORA_REGEX|$CENTOS8_REGEX ]]; then
     # Replace the first line in .py to "#!/usr/bin/env python2" no
     # matter what it was before


### PR DESCRIPTION
*Issue #, if available:*

#52 

*Description of changes:*

This PR extends the existing `mangle-shebangs.sh` to include CentOS 8. This will allow the package to be build and installed on CentOS 8.

Included in this PR:

- [x] `mangle-shebangs.sh` to include CentOS 8
- [x] Tests for CentOS 8
~~- [x] README update to include Centos 8 as supported distro~~

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.