### PR TITLE
add CentOS 8 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,6 +137,9 @@ workflows:
           name: centos7
           image: centos:centos7
       - build-rpm-package:
+          name: centos8
+          image: centos:centos8
+      - build-rpm-package:
           name: amazon-linux-2
           image: amazonlinux:2
       - build-rpm-package:

--- a/mangle-shebangs.sh
+++ b/mangle-shebangs.sh
@@ -3,9 +3,10 @@
 SYSTEM_RELEASE_PATH=/etc/system-release
 RHEL8_REGEX="Red Hat Enterprise Linux release 8"
 FEDORA_REGEX="Fedora release"
+CENTOS8_REGEX="CentOS Linux release 8"
 
-# RHEL8 and Fedora30+ both treat shebangs of the form "#!/usr/bin/env python" as errors
-if [ -f $SYSTEM_RELEASE_PATH ] && [[ "$(cat $SYSTEM_RELEASE_PATH)" =~ $RHEL8_REGEX|$FEDORA_REGEX ]]; then
+# RHEL8, Fedora30+ and CentOS8 treat shebangs of the form "#!/usr/bin/env python" as errors
+if [ -f $SYSTEM_RELEASE_PATH ] && [[ "$(cat $SYSTEM_RELEASE_PATH)" =~ $RHEL8_REGEX|$FEDORA_REGEX|$CENTOS8_REGEX ]]; then
     # Replace the first line in .py to "#!/usr/bin/env python2" no
     # matter what it was before
     sed -i -e '1 s/^.*$/\#!\/usr\/bin\/env python2/' src/watchdog/__init__.py


### PR DESCRIPTION
Single commit PR, replaces #53 

*Description of changes:*

This PR extends the existing `mangle-shebangs.sh` to include CentOS 8. This will allow the package to be build and installed on CentOS 8.

Included in this PR:

* `mangle-shebangs.sh` to include CentOS 8
* Tests for CentOS 8