### PR TITLE
Fix to use regional AWS STS endpoints instead of the global endpoint to reduce latency

### DIFF
--- a/test/mount_efs_test/test_get_aws_security_credentials.py
+++ b/test/mount_efs_test/test_get_aws_security_credentials.py
@@ -90,7 +90,7 @@ def test_get_aws_security_credentials_config_or_creds_file_found_creds_found_wit
     mocker.patch('os.path.exists', return_value=True)
     mocker.patch('mount_efs.credentials_file_helper', return_value=file_helper_resp)
 
-    credentials, credentials_source = mount_efs.get_aws_security_credentials(True, 'test_profile')
+    credentials, credentials_source = mount_efs.get_aws_security_credentials(True, 'us-east-1', 'test_profile')
 
     assert credentials['AccessKeyId'] == ACCESS_KEY_ID_VAL
     assert credentials['SecretAccessKey'] == SECRET_ACCESS_KEY_VAL
@@ -109,7 +109,7 @@ def test_get_aws_security_credentials_config_or_creds_file_found_creds_found_wit
     mocker.patch('os.path.exists', return_value=True)
     mocker.patch('mount_efs.credentials_file_helper', return_value=file_helper_resp)
 
-    credentials, credentials_source = mount_efs.get_aws_security_credentials(True, 'test_profile')
+    credentials, credentials_source = mount_efs.get_aws_security_credentials(True, 'us-east-1', 'test_profile')
 
     assert credentials['AccessKeyId'] == ACCESS_KEY_ID_VAL
     assert credentials['SecretAccessKey'] == SECRET_ACCESS_KEY_VAL
@@ -118,7 +118,7 @@ def test_get_aws_security_credentials_config_or_creds_file_found_creds_found_wit
 
 
 def test_get_aws_security_credentials_do_not_use_iam():
-    credentials, credentials_source = mount_efs.get_aws_security_credentials(False, 'test_profile')
+    credentials, credentials_source = mount_efs.get_aws_security_credentials(False, 'us-east-1', 'test_profile')
 
     assert not credentials
     assert not credentials_source
@@ -138,7 +138,7 @@ def _test_get_aws_security_credentials_get_ecs_from_env_url(mocker):
 
     mocker.patch('mount_efs.urlopen', return_value=MockUrlLibResponse(data=response))
 
-    credentials, credentials_source = mount_efs.get_aws_security_credentials(True, None)
+    credentials, credentials_source = mount_efs.get_aws_security_credentials(True, 'us-east-1', None)
 
     assert credentials['AccessKeyId'] == ACCESS_KEY_ID_VAL
     assert credentials['SecretAccessKey'] == SECRET_ACCESS_KEY_VAL
@@ -155,7 +155,7 @@ def test_get_aws_security_credentials_get_ecs_from_option_url(mocker):
         'Token': SESSION_TOKEN_VAL
     })
     mocker.patch('mount_efs.urlopen', return_value=MockUrlLibResponse(data=response))
-    credentials, credentials_source = mount_efs.get_aws_security_credentials(True, None, AWSCREDSURI)
+    credentials, credentials_source = mount_efs.get_aws_security_credentials(True, 'us-east-1', None, AWSCREDSURI)
 
     assert credentials['AccessKeyId'] == ACCESS_KEY_ID_VAL
     assert credentials['SecretAccessKey'] == SECRET_ACCESS_KEY_VAL
@@ -203,7 +203,7 @@ def _test_get_aws_security_credentials_get_instance_metadata_role_name(mocker, i
     side_effects = side_effects + [MockUrlLibResponse(data=role_name_data), MockUrlLibResponse(data=response)]
     mocker.patch('mount_efs.urlopen', side_effect=side_effects)
 
-    credentials, credentials_source = mount_efs.get_aws_security_credentials(True, None)
+    credentials, credentials_source = mount_efs.get_aws_security_credentials(True, 'us-east-1', None)
 
     assert credentials['AccessKeyId'] == ACCESS_KEY_ID_VAL
     assert credentials['SecretAccessKey'] == SECRET_ACCESS_KEY_VAL
@@ -217,7 +217,7 @@ def test_get_aws_security_credentials_no_credentials_found(mocker, capsys):
     mocker.patch('mount_efs.urlopen')
 
     with pytest.raises(SystemExit) as ex:
-        mount_efs.get_aws_security_credentials(True, None)
+        mount_efs.get_aws_security_credentials(True, 'us-east-1', None)
 
     assert 0 != ex.value.code
 
@@ -232,7 +232,7 @@ def test_get_aws_security_credentials_credentials_not_found_in_files(mocker, cap
     mocker.patch('mount_efs.urlopen')
 
     with pytest.raises(SystemExit) as ex:
-        mount_efs.get_aws_security_credentials(True, 'default')
+        mount_efs.get_aws_security_credentials(True, 'us-east-1', 'default')
 
     assert 0 != ex.value.code
 
@@ -245,7 +245,7 @@ def test_get_aws_security_credentials_credentials_not_found_in_aws_creds_uri(moc
     mocker.patch('mount_efs.urlopen')
 
     with pytest.raises(SystemExit) as ex:
-        mount_efs.get_aws_security_credentials(True, 'default', AWSCREDSURI)
+        mount_efs.get_aws_security_credentials(True, 'us-east-1', 'default', AWSCREDSURI)
 
     assert 0 != ex.value.code
 

--- a/test/watchdog_test/test_get_aws_security_credentials.py
+++ b/test/watchdog_test/test_get_aws_security_credentials.py
@@ -89,7 +89,7 @@ def test_get_aws_security_credentials_credentials_file_found_credentials_found_w
     mocker.patch('os.path.exists', return_value=True)
     mocker.patch('watchdog.credentials_file_helper', return_value=file_helper_resp)
 
-    credentials = watchdog.get_aws_security_credentials('credentials:default')
+    credentials = watchdog.get_aws_security_credentials('credentials:default', 'us-east-1')
 
     assert credentials['AccessKeyId'] == ACCESS_KEY_ID_VAL
     assert credentials['SecretAccessKey'] == SECRET_ACCESS_KEY_VAL
@@ -107,7 +107,7 @@ def test_get_aws_security_credentials_config_file_found_credentials_found_withou
     mocker.patch('os.path.exists', return_value=True)
     mocker.patch('watchdog.credentials_file_helper', return_value=file_helper_resp)
 
-    credentials = watchdog.get_aws_security_credentials('config:default')
+    credentials = watchdog.get_aws_security_credentials('config:default', 'us-east-1')
 
     assert credentials['AccessKeyId'] == ACCESS_KEY_ID_VAL
     assert credentials['SecretAccessKey'] == SECRET_ACCESS_KEY_VAL
@@ -125,7 +125,7 @@ def test_get_aws_security_credentials_credentials_file_found_credentials_found(m
     mocker.patch('os.path.exists', return_value=True)
     mocker.patch('watchdog.credentials_file_helper', return_value=file_helper_resp)
 
-    credentials = watchdog.get_aws_security_credentials('credentials:default')
+    credentials = watchdog.get_aws_security_credentials('credentials:default', 'us-east-1')
 
     assert credentials['AccessKeyId'] == ACCESS_KEY_ID_VAL
     assert credentials['SecretAccessKey'] == SECRET_ACCESS_KEY_VAL
@@ -143,7 +143,7 @@ def test_get_aws_security_credentials_config_file_found_credentials_found(mocker
     mocker.patch('os.path.exists', return_value=True)
     mocker.patch('watchdog.credentials_file_helper', return_value=file_helper_resp)
 
-    credentials = watchdog.get_aws_security_credentials('config:default')
+    credentials = watchdog.get_aws_security_credentials('config:default', 'us-east-1')
 
     assert credentials['AccessKeyId'] == ACCESS_KEY_ID_VAL
     assert credentials['SecretAccessKey'] == SECRET_ACCESS_KEY_VAL
@@ -163,7 +163,7 @@ def test_get_aws_security_credentials_ecs(mocker):
     mocker.patch.dict(os.environ, {'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI': 'fake_uri'})
     mocker.patch('watchdog.urlopen', return_value=MockUrlLibResponse(data=response))
 
-    credentials = watchdog.get_aws_security_credentials('ecs:fake_uri')
+    credentials = watchdog.get_aws_security_credentials('ecs:fake_uri', 'us-east-1')
 
     assert credentials['AccessKeyId'] == ACCESS_KEY_ID_VAL
     assert credentials['SecretAccessKey'] == SECRET_ACCESS_KEY_VAL
@@ -211,7 +211,7 @@ def _test_get_aws_security_credentials_instance_metadata_role_name(mocker, is_na
     side_effects = side_effects + [MockUrlLibResponse(data=role_name_data), MockUrlLibResponse(data=response)]
     mocker.patch('watchdog.urlopen', side_effect=side_effects)
 
-    credentials = watchdog.get_aws_security_credentials('metadata:')
+    credentials = watchdog.get_aws_security_credentials('metadata:', 'us-east-1')
 
     assert credentials['AccessKeyId'] == ACCESS_KEY_ID_VAL
     assert credentials['SecretAccessKey'] == SECRET_ACCESS_KEY_VAL
@@ -219,13 +219,13 @@ def _test_get_aws_security_credentials_instance_metadata_role_name(mocker, is_na
 
 
 def test_get_aws_security_credentials_not_found_bad_credentials_source():
-    credentials = watchdog.get_aws_security_credentials('dummy:source')
+    credentials = watchdog.get_aws_security_credentials('dummy:source', 'us-east-1')
     assert not credentials
 
 
 def test_get_aws_security_credentials_not_found_file_not_found(mocker):
     mocker.patch('os.path.exists', return_value=False)
-    credentials = watchdog.get_aws_security_credentials('credentials:default')
+    credentials = watchdog.get_aws_security_credentials('credentials:default', 'us-east-1')
     assert not credentials
 
 
@@ -233,19 +233,19 @@ def test_get_aws_security_credentials_not_found_file_found_no_creds(mocker):
     file_helper_resp = {'AccessKeyId': None, 'SecretAccessKey': None, 'Token': None}
     mocker.patch('os.path.exists', return_value=True)
     mocker.patch('watchdog.credentials_file_helper', return_value=file_helper_resp)
-    credentials = watchdog.get_aws_security_credentials('credentials:default')
+    credentials = watchdog.get_aws_security_credentials('credentials:default', 'us-east-1')
     assert not credentials
 
 
 def test_get_aws_security_credentials_ecs_no_response(mocker):
     mocker.patch('watchdog.url_request_helper', return_value=None)
-    credentials = watchdog.get_aws_security_credentials('ecs:fake_uri')
+    credentials = watchdog.get_aws_security_credentials('ecs:fake_uri', 'us-east-1')
     assert not credentials
 
 
 def test_get_aws_security_credentials_instance_metadata_no_response(mocker):
     mocker.patch('watchdog.url_request_helper', return_value=None)
-    credentials = watchdog.get_aws_security_credentials('metadata:')
+    credentials = watchdog.get_aws_security_credentials('metadata:', 'us-east-1')
     assert not credentials
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This pr fix to use regional AWS STS endpoints instead of the global endpoint to reduce latency.
[Managing AWS STS in an AWS Region](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html)

Currently, AWS STS global endpoint is used and the latency is high. Therefore, when executing from the Tokyo region(ap-northeast-1), a timeout error occurs in the SSL connection.

```
Traceback (most recent call last):
  File "/sbin/mount.efs", line 2071, in <module>
    main()
  File "/sbin/mount.efs", line 2065, in main
    mount_tls(config, init_system, dns_name, path, fs_id, mountpoint, options)
  File "/sbin/mount.efs", line 1644, in mount_tls
    with bootstrap_tls(config, init_system, dns_name, fs_id, mountpoint, options) as tunnel_proc:
  File "/lib64/python3.7/contextlib.py", line 112, in __enter__
    return next(self.gen)
  File "/sbin/mount.efs", line 963, in bootstrap_tls
    security_credentials, credentials_source = get_aws_security_credentials(use_iam, **kwargs)
  File "/sbin/mount.efs", line 385, in get_aws_security_credentials
    False
  File "/sbin/mount.efs", line 459, in get_aws_security_credentials_from_webidentity
    resp = url_request_helper(webidentity_url, unsuccessful_resp, url_error_msg, headers={'Accept': 'application/json'})
  File "/sbin/mount.efs", line 550, in url_request_helper
    request_resp = urlopen(req, timeout=1)

  File "/lib64/python3.7/urllib/request.py", line 222, in urlopen
    return opener.open(url, data, timeout)

  File "/lib64/python3.7/urllib/request.py", line 525, in open
    response = self._open(req, data)

  File "/lib64/python3.7/urllib/request.py", line 543, in _open
    '_open', req)

  File "/lib64/python3.7/urllib/request.py", line 503, in _call_chain
    result = func(*args)

  File "/lib64/python3.7/urllib/request.py", line 1393, in https_open
    context=self._context, check_hostname=self._check_hostname)

  File "/lib64/python3.7/urllib/request.py", line 1353, in do_open
    r = h.getresponse()

  File "/lib64/python3.7/http/client.py", line 1369, in getresponse
    response.begin()

  File "/lib64/python3.7/http/client.py", line 310, in begin
    version, status, reason = self._read_status()

  File "/lib64/python3.7/http/client.py", line 271, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")

  File "/lib64/python3.7/socket.py", line 589, in readinto
    return self._sock.recv_into(b)

  File "/lib64/python3.7/ssl.py", line 1071, in recv_into
    return self.read(nbytes, buffer)

  File "/lib64/python3.7/ssl.py", line 929, in read
    return self._sslobj.read(len, buffer)

socket.timeout: The read operation timed out
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
