### PR TITLE
Mount by IP for clusters with DNS hostnames disabled

### DIFF
--- a/man/mount.efs.8
+++ b/man/mount.efs.8
@@ -113,6 +113,10 @@ Mount the EFS file system to the specified availability zone mount target\&.
 .TP
 \fBmountport\fR
 Use the port 2049 to bypass portmapper daemon on EC2 Mac instances running macOS Big Sur\&.
+.TP
+\fBdnshostnamesdisabled\fR
+Mount the EFS file system by IP address. This option is intended for VPCs with DNS hostnames disabled. \
+In order to use this option your instance must have access to the elasticfilesystem::DescribeMountTargets API\&.
 .if n \{\
 .RE
 .\}
@@ -167,6 +171,10 @@ sudo mount -t efs -o tls,iam fs-abcd1234 /mnt/efs
 Mount an EFS file system with file system ID "fs-abcd1234" at mount point "/mnt/efs" \
 with encryption of data in transit. The mount helper will authenticate with EFS using \
 the system's IAM identity\&.
+.TP
+sudo mount -t efs -o tls,dnshostnamesdisabled fs-abcd1234 /mnt/efs
+Mount an EFS file system by IP with file system ID "fs-abcd1234" at mount point \
+"/mnt/efs" in a VPC with DNS hostnames disabled using encryption of data in transit\&.
 .TP
 sudo mount -t efs -o tls,accesspoint=fsap-12345678 fs-abcd1234 /mnt/efs
 Mount an EFS file system with file system ID "fs-abcd1234" at mount point "/mnt/efs" \

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -1514,14 +1514,16 @@ def get_dns_name(config, fs_id, options):
 
     dns_name = dns_name_format.format(**format_args)
 
+    return dns_name
+
+
+def validate_dns_resolves(dns_name):
     try:
         socket.gethostbyname(dns_name)
     except socket.gaierror:
         fatal_error('Failed to resolve "%s" - check that your file system ID is correct.\nSee %s for more detail.'
                     % (dns_name, 'https://docs.aws.amazon.com/console/efs/mount-dns-name'),
                     'Failed to resolve "%s"' % dns_name)
-
-    return dns_name
 
 
 def tls_paths_dictionary(mount_name, base_path=STATE_FILE_DIR):
@@ -1717,6 +1719,7 @@ def match_device(config, device, options):
                     'mount options, expected = %s, given = %s' % (hostname, remote, options['az'], az))
 
             expected_dns_name = get_dns_name(config, fs_id, add_field_in_options(options, 'az', az))
+            validate_dns_resolves(expected_dns_name)
 
             # check that the DNS name of the mount target matches exactly the DNS name the CNAME resolves to
             if hostname == expected_dns_name:
@@ -2189,6 +2192,7 @@ def main():
     check_network_status(fs_id, init_system)
 
     dns_name = get_dns_name(config, fs_id, options)
+    validate_dns_resolves(dns_name)
 
     if 'tls' in options:
         mount_tls(config, init_system, dns_name, path, fs_id, mountpoint, options)

--- a/test/mount_efs_test/test_get_dns_name.py
+++ b/test/mount_efs_test/test_get_dns_name.py
@@ -134,20 +134,6 @@ def test_get_dns_name_bad_format_too_many_specifiers_2(mocker):
     assert 'incorrect number' in str(ex.value)
 
 
-def test_get_dns_name_unresolvable(mocker, capsys):
-    config = _get_mock_config()
-
-    mocker.patch('socket.gethostbyname', side_effect=socket.gaierror)
-
-    with pytest.raises(SystemExit) as ex:
-        mount_efs.get_dns_name(config, FS_ID, DEFAULT_NFS_OPTIONS)
-
-    assert 0 != ex.value.code
-
-    out, err = capsys.readouterr()
-    assert 'Failed to resolve' in err
-
-
 def test_get_dns_name_special_region(mocker):
     for special_region in SPECIAL_REGIONS:
         mocker.patch('mount_efs.get_target_region', return_value=special_region)

--- a/test/mount_efs_test/test_get_mount_target_ip.py
+++ b/test/mount_efs_test/test_get_mount_target_ip.py
@@ -1,0 +1,122 @@
+#
+# Copyright 2017-2018 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the MIT License. See the LICENSE accompanying this file
+# for the specific language governing permissions and limitations under
+# the License.
+#
+
+import mount_efs
+
+import pytest
+
+from mock import MagicMock
+from botocore.stub import Stubber
+
+
+FS_ID = 'fs-deadbeef'
+DEFAULT_REGION = 'us-east-1'
+TARGET_SUBNET_ID = "subnet-111111111111"
+UNKNOWN_SUBNET_ID = "subnet-333333333333"
+DESCRIBE_MOUNT_TARGETS_RESPONSE = {
+  "ResponseMetadata": {
+    "RequestId": "00000000",
+    "HTTPStatusCode": 200,
+    "HTTPHeaders": {
+      "x-amzn-requestid": "00000000",
+      "content-type": "application/json",
+      "content-length": "1024",
+      "date": "Wed, 31 Mar 2021 01:17:08 GMT"
+    },
+    "RetryAttempts": 0
+  },
+  "MountTargets": [
+    {
+      "OwnerId": "123456789",
+      "MountTargetId": "fsmt-1111111111111",
+      "FileSystemId": FS_ID,
+      "SubnetId": TARGET_SUBNET_ID,
+      "LifeCycleState": "available",
+      "IpAddress": "10.0.0.1",
+      "NetworkInterfaceId": "eni-1",
+      "AvailabilityZoneId": "usw2-az1",
+      "AvailabilityZoneName": "us-west-2a",
+      "VpcId": "vpc-12345678"
+    },
+    {
+      "OwnerId": "123456789",
+      "MountTargetId": "fsmt-2222222222222",
+      "FileSystemId": FS_ID,
+      "SubnetId": "subnet-222222222222",
+      "LifeCycleState": "available",
+      "IpAddress": "10.0.0.2",
+      "NetworkInterfaceId": "eni-2",
+      "AvailabilityZoneId": "usw2-az3",
+      "AvailabilityZoneName": "us-west-2c",
+      "VpcId": "vpc-12345678"
+    },
+    {
+      "OwnerId": "123456789",
+      "MountTargetId": "fsmt-3333333333333",
+      "FileSystemId": FS_ID,
+      "SubnetId": TARGET_SUBNET_ID,
+      "LifeCycleState": "available",
+      "IpAddress": "10.0.0.3",
+      "NetworkInterfaceId": "eni-3",
+      "AvailabilityZoneId": "usw2-az1",
+      "AvailabilityZoneName": "us-west-2a",
+      "VpcId": "vpc-12345678"
+    }
+  ]
+}
+EXPECTED_DESCRIBE_MOUNT_TARGETS_PARAMS = {'FileSystemId': FS_ID}
+
+
+@pytest.fixture(autouse=True)
+def setup(mocker):
+    mocker.patch('mount_efs.get_target_region', return_value=DEFAULT_REGION)
+
+
+def test_get_mount_target_ip(mocker):
+    mock_config = MagicMock()
+    efs_client = mount_efs.get_botocore_client(mock_config, 'efs')
+
+    with Stubber(efs_client) as stubber:
+        stubber.add_response('describe_mount_targets', DESCRIBE_MOUNT_TARGETS_RESPONSE, EXPECTED_DESCRIBE_MOUNT_TARGETS_PARAMS)
+
+        mount_target_ip = mount_efs.get_mount_target_ip(efs_client, FS_ID, [TARGET_SUBNET_ID])
+        assert mount_target_ip == '10.0.0.1'
+
+
+def test_get_mount_target_ip_no_results(mocker, capsys):
+    mock_config = MagicMock()
+    efs_client = mount_efs.get_botocore_client(mock_config, 'efs')
+
+    with Stubber(efs_client) as stubber:
+        stubber.add_response('describe_mount_targets', DESCRIBE_MOUNT_TARGETS_RESPONSE, EXPECTED_DESCRIBE_MOUNT_TARGETS_PARAMS)
+
+        with pytest.raises(SystemExit) as ex:
+            mount_efs.get_mount_target_ip(efs_client, FS_ID, [UNKNOWN_SUBNET_ID])
+
+    assert 0 != ex.value.code
+
+    out, err = capsys.readouterr()
+    assert 'Failed to locate any mount targets' in err
+
+
+def test_get_mount_target_ip_client_error(mocker, capsys):
+    mock_config = MagicMock()
+    efs_client = mount_efs.get_botocore_client(mock_config, 'efs')
+
+    with Stubber(efs_client) as stubber:
+        stubber.add_client_error('describe_mount_targets',
+                                 service_error_code='FileSystemNotFound',
+                                 service_message='File system not found')
+
+        with pytest.raises(SystemExit) as ex:
+            mount_efs.get_mount_target_ip(efs_client, FS_ID, [TARGET_SUBNET_ID])
+
+    assert 0 != ex.value.code
+
+    out, err = capsys.readouterr()
+    assert 'File system not found' in err

--- a/test/mount_efs_test/test_main.py
+++ b/test/mount_efs_test/test_main.py
@@ -61,7 +61,8 @@ def _test_main(mocker, tls=False, root=True, ap_id=None, iam=False, awsprofile=N
         mocker.patch('os.geteuid', return_value=100)
 
     bootstrap_logging_mock = mocker.patch('mount_efs.bootstrap_logging')
-    get_dns_mock = mocker.patch('mount_efs.get_dns_name')
+    get_dns_mock = mocker.patch('mount_efs.get_dns_name', return_value='fs-deadbeef.efs.us-east-1.amazonaws.com')
+    get_host_by_name_mock = mocker.patch('socket.gethostbyname')
     parse_arguments_mock = mocker.patch('mount_efs.parse_arguments', return_value=('fs-deadbeef', '/', '/mnt', options))
     bootstrap_tls_mock = mocker.patch('mount_efs.bootstrap_tls', side_effect=dummy_contextmanager)
     if tls:

--- a/test/mount_efs_test/test_match_device.py
+++ b/test/mount_efs_test/test_match_device.py
@@ -87,6 +87,20 @@ def test_match_device_correct_descriptors_fs_id(mocker):
         assert (fs_id, path, az) == mount_efs.match_device(config, device, DEFAULT_NFS_OPTIONS)
 
 
+def test_match_device_dns_hostnames_disabled_no_fs_id(capsys):
+    config = _get_mock_config()
+    dns_name = '%s.efs.us-east-1.amazonaws.com' % FS_ID
+    options = {'dnshostnamesdisabled': None}
+
+    with pytest.raises(SystemExit) as ex:
+        mount_efs.match_device(config, dns_name, options)
+
+    assert 0 != ex.value.code
+
+    out, err = capsys.readouterr()
+    assert 'IP lookup for option dnshostnamesdisabled only works with a filesystem ID' in err
+
+
 def test_match_device_correct_descriptors_cname_dns_suffix_override_region(mocker):
     get_dns_name_mock = mocker.patch('mount_efs.get_dns_name', return_value='fs-deadbeef.efs.cn-north-1.amazonaws.com.cn')
     gethostbyname_ex_mock = mocker.patch('socket.gethostbyname_ex',

--- a/test/mount_efs_test/test_set_derived_options.py
+++ b/test/mount_efs_test/test_set_derived_options.py
@@ -1,0 +1,49 @@
+#
+# Copyright 2017-2018 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the MIT License. See the LICENSE accompanying this file
+# for the specific language governing permissions and limitations under
+# the License.
+#
+
+import mount_efs
+
+import pytest
+
+from mock import MagicMock
+
+
+DEFAULT_REGION = 'us-east-1'
+FS_ID = 'fs-deadbeef'
+
+
+@pytest.fixture(autouse=True)
+def setup(mocker):
+    mocker.patch('mount_efs.get_target_region', return_value=DEFAULT_REGION)
+
+
+def test_set_derived_options(mocker, capsys):
+    mocker.patch('mount_efs.get_subnet_ids', return_value=['subnet-111111111111'])
+    mocker.patch('mount_efs.get_mount_target_ip', return_value='10.0.0.1')
+
+    config = MagicMock()
+    options = {'dnshostnamesdisabled': None}
+
+    mount_efs.set_derived_options(config, FS_ID, options)
+
+    assert options['mounttargetip'] == '10.0.0.1'
+
+
+def test_set_derived_options_no_subnet_ids(mocker, capsys):
+    mocker.patch('mount_efs.get_subnet_ids', return_value=[])
+
+    config = MagicMock()
+    options = {'dnshostnamesdisabled': None}
+
+    with pytest.raises(SystemExit) as ex:
+        mount_efs.set_derived_options(config, FS_ID, options)
+
+    assert 0 != ex.value.code
+
+    out, err = capsys.readouterr()
+    assert 'Failed to find subnet IDs for network interfaces attached to instance' in err

--- a/test/mount_efs_test/test_validate_dns_resolves.py
+++ b/test/mount_efs_test/test_validate_dns_resolves.py
@@ -1,0 +1,24 @@
+#
+# Copyright 2017-2018 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the MIT License. See the LICENSE accompanying this file
+# for the specific language governing permissions and limitations under
+# the License.
+#
+
+import mount_efs
+import socket
+
+import pytest
+
+
+def test_validate_dns_resolves_unresolvable(mocker, capsys):
+    mocker.patch('socket.gethostbyname', side_effect=socket.gaierror)
+
+    with pytest.raises(SystemExit) as ex:
+        mount_efs.validate_dns_resolves("fs-deadbeef.efs.us-west-2.amazonaws.com")
+
+    assert 0 != ex.value.code
+
+    out, err = capsys.readouterr()
+    assert 'Failed to resolve' in err


### PR DESCRIPTION
*Issue #, if available:*

- This issue is related, but the proposed solution may differ from what's implemented here: #63
- [This issue](https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/285) in the AWS EFS CSI driver repo is also related and depends on this (or a similar) feature.

*Description of changes:*

This introduces a [`dnshostnamesdisabled`](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-dns.html) option to supply during mount. When supplied, the efs-utils package will lookup an IP address (using AWS APIs) of a matching mount target and mount using the IP address.

An IP address is chosen by fetching the mount targets for the given filesystem ID using AWS APIs, and filtering them by the subnet IDs of the subnets of the network interfaces attached to the instance. The first matching mount target IP address is chosen. If no such mount target exists, return an error.

Note that all attached network interfaces will share the same subnet, but this solution would also work in the situation that they weren't all in the same subnet.

Using this option enables users to mount file systems in clusters with DNS hostnames disabled, while still leveraging TLS.

Note that in order to use this feature:

- The host must have the `botocore` library installed
- The instance must have an IAM role with access to the [`elasticfilesystem:DescribeMountTargets`](https://docs.aws.amazon.com/efs/latest/ug/API_DescribeMountTargets.html) API

https://docs.aws.amazon.com/efs/latest/ug/API_DescribeMountTargets.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

@msau, @Cappuccinuo 