### PR TITLE
Support Oracle Enterprise Linux 8

### DIFF
--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -226,13 +226,14 @@ SYSTEM_RELEASE_PATH = '/etc/system-release'
 OS_RELEASE_PATH = '/etc/os-release'
 RHEL8_RELEASE_NAME = 'Red Hat Enterprise Linux release 8'
 CENTOS8_RELEASE_NAME = 'CentOS Linux release 8'
+ORACLE_RELEASE_NAME = 'Oracle Linux Server release 8'
 FEDORA_RELEASE_NAME = 'Fedora release'
 OPEN_SUSE_LEAP_RELEASE_NAME = 'openSUSE Leap'
 SUSE_RELEASE_NAME = 'SUSE Linux Enterprise Server'
 MACOS_BIG_SUR_RELEASE = 'macOS-11'
 
 SKIP_NO_LIBWRAP_RELEASES = [RHEL8_RELEASE_NAME, CENTOS8_RELEASE_NAME, FEDORA_RELEASE_NAME, OPEN_SUSE_LEAP_RELEASE_NAME,
-                            SUSE_RELEASE_NAME, MACOS_BIG_SUR_RELEASE]
+                            SUSE_RELEASE_NAME, MACOS_BIG_SUR_RELEASE, ORACLE_RELEASE_NAME]
 
 # Multiplier for max read ahead buffer size
 # Set default as 15 aligning with prior linux kernel 5.4


### PR DESCRIPTION
- Changed to prevent from using libwrap option on Oracle EL8

*Issue #, if available:*
  Oracle Enterprise Linux 8 does not support TCP wrapper as RHEL 8 or CentOS 8 does.
  Because of the absence of the release name of the OS in the "SKIP_NO_LIBWRAP_RELEASES", the mount script always try to use the libwrap option with stunnel.

*Description of changes:*
  I added a ORACLE_RELEASE_NAME variable and added it in the "SKIP_NO_LIBWRAP_RELEASES" not to use the libwrap option.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
