### PR TITLE
Added support for Almalinux 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,6 +179,18 @@ workflows:
           name: debian11
           image: debian:bullseye
       - build-rpm-package:
+          name: rockylinux8.4
+          image: rockylinux/rockylinux:8.4
+      - build-rpm-package:
+          name: almalinux8.4
+          image: almalinux:8.4
+      - build-rpm-package:
+          name: rockylinux8
+          image: rockylinux/rockylinux:8
+      - build-rpm-package:
+          name: almalinux8
+          image: almalinux:8
+      - build-rpm-package:
           name: centos7
           image: centos:centos7
       - build-rpm-package:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,6 +191,9 @@ workflows:
           name: centos8
           image: centos:centos8
       - build-rpm-package:
+          name: rocky8
+          image: rockylinux/rockylinux:8
+      - build-rpm-package:
           name: amazon-linux-2
           image: amazonlinux:2
       - build-rpm-package:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,12 +179,6 @@ workflows:
           name: debian11
           image: debian:bullseye
       - build-rpm-package:
-          name: rockylinux8.4
-          image: rockylinux/rockylinux:8.4
-      - build-rpm-package:
-          name: almalinux8.4
-          image: almalinux:8.4
-      - build-rpm-package:
           name: rockylinux8
           image: rockylinux/rockylinux:8
       - build-rpm-package:

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ The `efs-utils` package has been verified against the following Linux distributi
 | ------------ | ------------ | ------------- |
 | Amazon Linux 2017.09 | `rpm` | `upstart` |
 | Amazon Linux 2 | `rpm` | `systemd` |
-| Almalinux 8.4 | `rpm` | `systemd` |
-| RockyLinux 8.4 | `rpm` | `systemd` |
 | CentOS 7 | `rpm` | `systemd` |
 | CentOS 8 | `rpm` | `systemd` |
 | RHEL 7 | `rpm`| `systemd` |

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ The `efs-utils` package has been verified against the following Linux distributi
 | ------------ | ------------ | ------------- |
 | Amazon Linux 2017.09 | `rpm` | `upstart` |
 | Amazon Linux 2 | `rpm` | `systemd` |
+| Almalinux 8.4 | `rpm` | `systemd` |
+| RockyLinux 8.3 | `rpm` | `systemd` |
+| RockyLinux 8.4 | `rpm` | `systemd` |
 | CentOS 7 | `rpm` | `systemd` |
 | CentOS 8 | `rpm` | `systemd` |
 | RHEL 7 | `rpm`| `systemd` |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ The `efs-utils` package has been verified against the following Linux distributi
 | Amazon Linux 2017.09 | `rpm` | `upstart` |
 | Amazon Linux 2 | `rpm` | `systemd` |
 | Almalinux 8.4 | `rpm` | `systemd` |
-| RockyLinux 8.3 | `rpm` | `systemd` |
 | RockyLinux 8.4 | `rpm` | `systemd` |
 | CentOS 7 | `rpm` | `systemd` |
 | CentOS 8 | `rpm` | `systemd` |

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -241,13 +241,11 @@ ORACLE_RELEASE_NAME = 'Oracle Linux Server release 8'
 FEDORA_RELEASE_NAME = 'Fedora release'
 OPEN_SUSE_LEAP_RELEASE_NAME = 'openSUSE Leap'
 SUSE_RELEASE_NAME = 'SUSE Linux Enterprise Server'
-ALMALINUX_8_4_RELEASE_NAME = 'AlmaLinux release 8.4 (Electric Cheetah)'
 ALMALINUX_8_RELEASE_NAME = 'AlmaLinux release 8'
 MACOS_BIG_SUR_RELEASE = 'macOS-11'
 
 SKIP_NO_LIBWRAP_RELEASES = [RHEL8_RELEASE_NAME, CENTOS8_RELEASE_NAME, FEDORA_RELEASE_NAME, OPEN_SUSE_LEAP_RELEASE_NAME,
-                            SUSE_RELEASE_NAME, MACOS_BIG_SUR_RELEASE, ORACLE_RELEASE_NAME, ALMALINUX_8_4_RELEASE_NAME,
-                            ALMALINUX_8_RELEASE_NAME]
+                            SUSE_RELEASE_NAME, MACOS_BIG_SUR_RELEASE, ORACLE_RELEASE_NAME, ALMALINUX_8_RELEASE_NAME]
 
 # Multiplier for max read ahead buffer size
 # Set default as 15 aligning with prior linux kernel 5.4

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -242,12 +242,12 @@ FEDORA_RELEASE_NAME = 'Fedora release'
 OPEN_SUSE_LEAP_RELEASE_NAME = 'openSUSE Leap'
 SUSE_RELEASE_NAME = 'SUSE Linux Enterprise Server'
 ALMALINUX_8_4_RELEASE_NAME = 'AlmaLinux release 8.4 (Electric Cheetah)'
-ROCKYLINUX_8_4_RELEASE_NAME = 'Rocky Linux 8.4 (Green Obsidian)'
+ALMALINUX_8_RELEASE_NAME = 'AlmaLinux release 8'
 MACOS_BIG_SUR_RELEASE = 'macOS-11'
 
 SKIP_NO_LIBWRAP_RELEASES = [RHEL8_RELEASE_NAME, CENTOS8_RELEASE_NAME, FEDORA_RELEASE_NAME, OPEN_SUSE_LEAP_RELEASE_NAME,
                             SUSE_RELEASE_NAME, MACOS_BIG_SUR_RELEASE, ORACLE_RELEASE_NAME, ALMALINUX_8_4_RELEASE_NAME,
-                            ROCKYLINUX_8_4_RELEASE_NAME]
+                            ALMALINUX_8_RELEASE_NAME]
 
 # Multiplier for max read ahead buffer size
 # Set default as 15 aligning with prior linux kernel 5.4

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -242,13 +242,12 @@ FEDORA_RELEASE_NAME = 'Fedora release'
 OPEN_SUSE_LEAP_RELEASE_NAME = 'openSUSE Leap'
 SUSE_RELEASE_NAME = 'SUSE Linux Enterprise Server'
 ALMALINUX_8_4_RELEASE_NAME = 'AlmaLinux release 8.4 (Electric Cheetah)'
-ROCKYLINUX_8_3_RELEASE_NAME = 'Rocky Linux release 8.3'
-ROCKYLINUX_8_4_RELEASE_NAME = 'Rocky Linux release 8.4'
+ROCKYLINUX_8_4_RELEASE_NAME = 'Rocky Linux 8.4 (Green Obsidian)'
 MACOS_BIG_SUR_RELEASE = 'macOS-11'
 
 SKIP_NO_LIBWRAP_RELEASES = [RHEL8_RELEASE_NAME, CENTOS8_RELEASE_NAME, FEDORA_RELEASE_NAME, OPEN_SUSE_LEAP_RELEASE_NAME,
                             SUSE_RELEASE_NAME, MACOS_BIG_SUR_RELEASE, ORACLE_RELEASE_NAME, ALMALINUX_8_4_RELEASE_NAME,
-                            ROCKYLINUX_8_3_RELEASE_NAME, ROCKYLINUX_8_4_RELEASE_NAME]
+                            ROCKYLINUX_8_4_RELEASE_NAME]
 
 # Multiplier for max read ahead buffer size
 # Set default as 15 aligning with prior linux kernel 5.4

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -256,7 +256,31 @@ STUNNEL_EFS_CONFIG = {
 WATCHDOG_SERVICE = "amazon-efs-mount-watchdog"
 
 # MacOS instances use plist files. This files needs to be loaded on launchctl (init system of MacOS)
+<<<<<<< HEAD
 
+WATCHDOG_SERVICE_PLIST_PATH = "/Library/LaunchAgents/amazon-efs-mount-watchdog.plist"
+SYSTEM_RELEASE_PATH = "/etc/system-release"
+OS_RELEASE_PATH = "/etc/os-release"
+RHEL8_RELEASE_NAME = "Red Hat Enterprise Linux release 8"
+CENTOS8_RELEASE_NAME = "CentOS Linux release 8"
+ORACLE_RELEASE_NAME = "Oracle Linux Server release 8"
+FEDORA_RELEASE_NAME = "Fedora release"
+OPEN_SUSE_LEAP_RELEASE_NAME = "openSUSE Leap"
+SUSE_RELEASE_NAME = "SUSE Linux Enterprise Server"
+ALMALINUX_8_RELEASE_NAME = "AlmaLinux release 8"
+MACOS_BIG_SUR_RELEASE = "macOS-11"
+
+SKIP_NO_LIBWRAP_RELEASES = [
+    RHEL8_RELEASE_NAME,
+    CENTOS8_RELEASE_NAME,
+    FEDORA_RELEASE_NAME,
+    OPEN_SUSE_LEAP_RELEASE_NAME,
+    SUSE_RELEASE_NAME,
+    MACOS_BIG_SUR_RELEASE,
+    ORACLE_RELEASE_NAME,
+    ALMALINUX_8_RELEASE_NAME,
+]
+=======
 WATCHDOG_SERVICE_PLIST_PATH = '/Library/LaunchAgents/amazon-efs-mount-watchdog.plist'
 SYSTEM_RELEASE_PATH = '/etc/system-release'
 OS_RELEASE_PATH = '/etc/os-release'
@@ -271,6 +295,7 @@ MACOS_BIG_SUR_RELEASE = 'macOS-11'
 
 SKIP_NO_LIBWRAP_RELEASES = [RHEL8_RELEASE_NAME, CENTOS8_RELEASE_NAME, FEDORA_RELEASE_NAME, OPEN_SUSE_LEAP_RELEASE_NAME,
                             SUSE_RELEASE_NAME, MACOS_BIG_SUR_RELEASE, ORACLE_RELEASE_NAME, ALMALINUX_8_RELEASE_NAME]
+>>>>>>> 7700b1a (Squashed commits for AlmaLinux)
 
 # Multiplier for max read ahead buffer size
 # Set default as 15 aligning with prior linux kernel 5.4

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -241,10 +241,14 @@ ORACLE_RELEASE_NAME = 'Oracle Linux Server release 8'
 FEDORA_RELEASE_NAME = 'Fedora release'
 OPEN_SUSE_LEAP_RELEASE_NAME = 'openSUSE Leap'
 SUSE_RELEASE_NAME = 'SUSE Linux Enterprise Server'
+ALMALINUX_8_4_RELEASE_NAME = 'AlmaLinux release 8.4 (Electric Cheetah)'
+ROCKYLINUX_8_3_RELEASE_NAME = 'Rocky Linux release 8.3'
+ROCKYLINUX_8_4_RELEASE_NAME = 'Rocky Linux release 8.4'
 MACOS_BIG_SUR_RELEASE = 'macOS-11'
 
 SKIP_NO_LIBWRAP_RELEASES = [RHEL8_RELEASE_NAME, CENTOS8_RELEASE_NAME, FEDORA_RELEASE_NAME, OPEN_SUSE_LEAP_RELEASE_NAME,
-                            SUSE_RELEASE_NAME, MACOS_BIG_SUR_RELEASE, ORACLE_RELEASE_NAME]
+                            SUSE_RELEASE_NAME, MACOS_BIG_SUR_RELEASE, ORACLE_RELEASE_NAME, ALMALINUX_8_4_RELEASE_NAME,
+                            ROCKYLINUX_8_3_RELEASE_NAME, ROCKYLINUX_8_4_RELEASE_NAME]
 
 # Multiplier for max read ahead buffer size
 # Set default as 15 aligning with prior linux kernel 5.4


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I have added explicit release names for AlmaLinux 8.4 and Rocky Linux 8.3 and 8.4. Earlier, the mount helper was not working as it did not recognize that these releases also do not have libwrap just like RHEL 8 and CentOS 8. I have verified that it works on AlmaLinux and Rocky Linux on the specified versions.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
