### PR TITLE
Explicitly state that efs-utils only support EC2 Mac Big Sur, not local Mac computers

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,9 @@ $ sudo apt-get -y install ./build/amazon-efs-utils*deb
 
 ### On MacOS Big Sur distribution
 
-For EC2 Mac instances running macOS Big Sur, you can install amazon-efs-utils from the [homebrew-aws](https://github.com/aws/homebrew-aws) respository.
+For EC2 Mac instances running macOS Big Sur, you can install amazon-efs-utils from the 
+[homebrew-aws](https://github.com/aws/homebrew-aws) respository. **Note that this will ONLY work on EC2 instances
+running macOS Big Sur, not local Mac computers.**
 ```
 brew install amazon-efs-utils
 ```


### PR DESCRIPTION
Fix comments in https://github.com/aws/efs-utils/issues/113

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
