### PR TITLE
Fix error handling in stunnel process checking

### DIFF
--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -1282,10 +1282,12 @@ def test_tunnel_process(tunnel_proc, fs_id):
     tunnel_proc.poll()
     if tunnel_proc.returncode is not None:
         out, err = tunnel_proc.communicate()
+        stdstr = out.strip() if out is not None else '<none>'
+        errstr = err.strip() if err is not None else '<none>'
         fatal_error(
             "Failed to initialize TLS tunnel for %s" % fs_id,
             'Failed to start TLS tunnel (errno=%d). stdout="%s" stderr="%s"'
-            % (tunnel_proc.returncode, out.strip(), err.strip()),
+            % (tunnel_proc.returncode, stdstr, errstr)
         )
 
 


### PR DESCRIPTION
*Issue #, if available:*
Related to issue #105.

*Description of changes:*
The code that checks the spawned stunnel process started correctly tries to print out it's stderr and stdout strip()-ed in case a problem is encountered. However if any of the two output strings is empty, the attempt to strip the string will fail with unhandled exception. The patch sets a placeholder string in such a case allowing for the intended error handling to happen.