### PR TITLE
Tjamilkowski stunnel pid fix

### DIFF
--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -235,7 +235,7 @@ UNSUPPORTED_OPTIONS = ["capath"]
 STUNNEL_GLOBAL_CONFIG = {
     "fips": "no",
     "foreground": "yes",
-    'pid': '',
+    "pid": "",
     "socket": [
         "l:SO_REUSEADDR=yes",
         "a:SO_BINDTODEVICE=lo",

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -235,6 +235,7 @@ UNSUPPORTED_OPTIONS = ["capath"]
 STUNNEL_GLOBAL_CONFIG = {
     "fips": "no",
     "foreground": "yes",
+    'pid': '',
     "socket": [
         "l:SO_REUSEADDR=yes",
         "a:SO_BINDTODEVICE=lo",


### PR DESCRIPTION
*112*

*Add empty PID for global config to stunnel so to avoid race condition 2 instances of stunnel deleting the others PID and failing the efs mount on encrypted EFS volumes when 2 or more EFS volumes are being mounted*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
