### PR TITLE
detect invalid private key

### DIFF
--- a/src/watchdog/__init__.py
+++ b/src/watchdog/__init__.py
@@ -1363,7 +1363,11 @@ def check_and_create_private_key(base_path=STATE_FILE_DIR):
 
     def generate_key():
         if os.path.isfile(key):
-            return
+            if os.path.getsize(key) == 0:
+                logging.info("Purging empty private key file")
+                os.remove(key)
+            else:
+                return
 
         cmd = (
             "openssl genpkey -algorithm RSA -out %s -pkeyopt rsa_keygen_bits:3072" % key


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/683
https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/569

*Description of changes:*

The `privateKey.pem` can become an empty file due to several reasons, but this case is falsely detected as an existing valid key.
Instead of just assuming an existing file means a valid key, at least there should be a check if the file is not empty.
