### PR TITLE
Add separate env_path for macOS

### DIFF
--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -1085,9 +1085,17 @@ def _stunnel_bin():
 
 def find_command_path(command, install_method):
     try:
-        env_path = (
-            "/sbin:/usr/sbin:/usr/local/sbin:/root/bin:/usr/local/bin:/usr/bin:/bin"
-        )
+        # If not running on macOS, use linux paths
+        if not check_if_platform_is_mac():
+            env_path = (
+                "/sbin:/usr/sbin:/usr/local/sbin:/root/bin:/usr/local/bin:/usr/bin:/bin"
+            )
+        # Homebrew on x86 macOS uses /usr/local/bin; Homebrew on Apple Silicon macOS uses /opt/homebrew/bin since v3.0.0
+        # For more information, see https://brew.sh/2021/02/05/homebrew-3.0.0/
+        else:
+            env_path = (
+                "/opt/homebrew/bin:/usr/local/bin"
+            )
         os.putenv("PATH", env_path)
         path = subprocess.check_output(["which", command])
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Homebrew changed the default path for installs on Apple Silicon to /opt/homebrew/ (see https://brew.sh/2021/02/05/homebrew-3.0.0/) for more details.

This PR sets a different env_path for macOS which includes /opt/homebrew for Apple Silicon (EC2 M1 Mac instances) and /usr/local/bin which covers Intel-based EC2 x86 Mac instances.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
