### PR TITLE
Specify FIPS mode in configuration

### DIFF
--- a/dist/efs-utils.conf
+++ b/dist/efs-utils.conf
@@ -29,6 +29,9 @@ stunnel_check_cert_hostname = true
 # Use OCSP to check certificate validity. This option is not supported by certain stunnel versions.
 stunnel_check_cert_validity = false
 
+# Set to true to use FIPS-mode for stunnel.
+stunnel_fips_enabled = false
+
 # Define the port range that the TLS tunnel will choose from
 port_range_lower_bound = 20049
 port_range_upper_bound = 21049

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -1173,6 +1173,10 @@ def write_stunnel_config_file(
     global_config["pid"] = os.path.join(
         state_file_dir, mount_filename + "+", "stunnel.pid"
     )
+    if get_boolean_config_item_value(
+        config, CONFIG_SECTION, "stunnel_fips_enabled", default_value=False
+    ):
+        global_config["fips"] = "yes"
 
     efs_config = dict(STUNNEL_EFS_CONFIG)
     efs_config["accept"] = efs_config["accept"] % tls_port


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add logic to allow selection of FIPS mode for stunnel. If stunnel is dynamically linked to OpenSSL, the library may already enforce FIPS mode. But even in such cases, this allows configuring the machine so that the log file does not get populated with messages saying "FIPS mode is disabled" -- our auditors don't seem to like those :-)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
