### PR TITLE
Add ability to force usage of IP in the nfs mount command

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,12 @@ The access point must be in the "available" state before it can be used to mount
 $ sudo mount -t efs -o tls,accesspoint=access-point-id file-system-id efs-mount-point/
 ```
 
+To not use the DNS name in the mount command, and force the use of the resolved IP instead.  This option requires that `fall_back_to_mount_target_ip_address_enabled = true` is set in efs-utils.conf under the `[mount]` section.
+
+```bash
+$ sudo mount -t efs -o forceuseip file-system-id efs-mount-point/
+```
+
 To mount your file system automatically with any of the options above, you can add entries to `/efs/fstab` like:
 
 ```bash

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -2344,7 +2344,7 @@ def get_dns_name_and_fallback_mount_target_ip_address(config, fs_id, options):
                 ip_address=ip_address, fallback_message=fallback_message
             )
 
-    if not "forceuseip" in options:
+    if "forceuseip" not in options:
         if dns_name_can_be_resolved(dns_name):
             return dns_name, None
 
@@ -2353,9 +2353,9 @@ def get_dns_name_and_fallback_mount_target_ip_address(config, fs_id, options):
             dns_name,
         )
     else:
-       logging.info(
-           "Forcing the use of IP address in the mount. Attempting to lookup mount target ip address using botocore."
-       )
+        logging.info(
+            "Forcing the use of IP address in the mount. Attempting to lookup mount target ip address using botocore."
+        )
 
     try:
         fallback_mount_target_ip_address = get_fallback_mount_target_ip_address(

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -220,6 +220,7 @@ EFS_ONLY_OPTIONS = [
     "awsprofile",
     "az",
     "cafile",
+    "forceuseip",
     "iam",
     "mounttargetip",
     "netns",
@@ -2343,13 +2344,18 @@ def get_dns_name_and_fallback_mount_target_ip_address(config, fs_id, options):
                 ip_address=ip_address, fallback_message=fallback_message
             )
 
-    if dns_name_can_be_resolved(dns_name):
-        return dns_name, None
+    if not "forceuseip" in options:
+        if dns_name_can_be_resolved(dns_name):
+            return dns_name, None
 
-    logging.info(
-        "Failed to resolve %s, attempting to lookup mount target ip address using botocore.",
-        dns_name,
-    )
+        logging.info(
+            "Failed to resolve %s, attempting to lookup mount target ip address using botocore.",
+            dns_name,
+        )
+    else:
+       logging.info(
+           "Forcing the use of IP address in the mount. Attempting to lookup mount target ip address using botocore."
+       )
 
     try:
         fallback_mount_target_ip_address = get_fallback_mount_target_ip_address(


### PR DESCRIPTION
*Description of changes:*
Add a new mount option **forceuseip** that will cause a DNS lookup as it's currently done for the mount target but use the IP only in the NFS mount.

This is important for machines that run rpc.gssd with the -n argument to provide kerberized NFS to other shares, as without it, NFS mounts will search for a kerberos principal for ``nfs/mounttarget`` and fail with a 
``Key has expired`` message.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
