### PR TITLE
Disable journal entry fetch from systemctl call

### DIFF
--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -1350,7 +1350,7 @@ def check_network_target(fs_id):
     with open(os.devnull, "w") as devnull:
         if not check_if_platform_is_mac():
             rc = subprocess.call(
-                ["systemctl", "status", "network.target"],
+                ["systemctl", "is-active", "network.target"],
                 stdout=devnull,
                 stderr=devnull,
                 close_fds=True,


### PR DESCRIPTION
systemctl has known performance issues with large numbers of journal files.

See https://github.com/systemd/systemd/issues/2460.

Adding --lines=0 argument to call improves call speed when systemctl is called for the first time. If this first call happens from mount.efs, this may result in high latency for the mount as it waits for all of the journal files to be indexed. Given that mount.efs is only looking for the exit code of the command and does not care about the journal entries, there is no loss of usability by adding the flag.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
