### PR TITLE
Add efs-utils Support for MacOS Ventura EC2 instances.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The `efs-utils` package has been verified against the following MacOS distributi
 | -------------- | ------------- |
 | MacOS Big Sur  | `launchd` |
 | MacOS Monterey | `launchd` |
+| MacOS Ventura  | `launchd` |
 
 ## Prerequisites
 
@@ -58,7 +59,7 @@ $ sudo yum -y install amazon-efs-utils
 ```
 
 ### Install via AWS Systems Manager Distributor
-You can now use AWS Systems Manage Distributor to automatically install or update `amazon-efs-utils`. 
+You can now use AWS Systems Manage Distributor to automatically install or update `amazon-efs-utils`.
 Please refer to [Using AWS Systems Manager to automatically install or update Amazon EFS clients](https://docs.aws.amazon.com/efs/latest/ug/manage-efs-utils-with-aws-sys-manager.html) for more guidance.
 
 The following are prerequisites for using AWS Systems Manager Distributor to install or update `amazon-efs-utils`:
@@ -117,16 +118,16 @@ $ ./build-deb.sh
 $ sudo apt-get -y install ./build/amazon-efs-utils*deb
 ```
 
-### On MacOS Big Sur and macOS Monterey distribution
+### On macOS Big Sur, macOS Monterey, and macOS Ventura distributions
 
-For EC2 Mac instances running macOS Big Sur and macOS Monterey, you can install amazon-efs-utils from the 
+For EC2 Mac instances running macOS Big Sur, macOS Monterey and macOS Ventura, you can install amazon-efs-utils from the
 [homebrew-aws](https://github.com/aws/homebrew-aws) respository. **Note that this will ONLY work on EC2 instances
 running macOS Big Sur and macOS Monterey, not local Mac computers.**
 ```bash
 brew install amazon-efs-utils
 ```
 
-This will install amazon-efs-utils on your EC2 Mac Instance running macOS Big Sur and macOS Monterey in the directory `/usr/local/Cellar/amazon-efs-utils`. At the end of the installation, it will print a set of commands that must be executed in order to start using efs-utils. The instructions that are printed after amazon-efs-utils and must be executed are:
+This will install amazon-efs-utils on your EC2 Mac Instance in the directory `/usr/local/Cellar/amazon-efs-utils`. At the end of the installation, it will print a set of commands that must be executed in order to start using efs-utils. The instructions that are printed after amazon-efs-utils and must be executed are:
 
 ```bash
 # Perform below actions to start using efs:
@@ -223,7 +224,7 @@ man mount.efs
 
 or refer to the [documentation](https://docs.aws.amazon.com/efs/latest/ug/using-amazon-efs-utils.html).
 
-### MacOS 
+### MacOS
 
 For EC2 instances using Mac distribution, the recommended default options will perform a tls mount:
 
@@ -248,7 +249,7 @@ $ sudo mount -t efs -o notls file-system-id efs-mount-point/
 
 ## Upgrading stunnel for RHEL/CentOS
 
-By default, when using the EFS mount helper with TLS, it enforces certificate hostname checking. The EFS mount helper uses the `stunnel` program for its TLS functionality. Please note that some versions of Linux do not include a version of `stunnel` that supports TLS features by default. When using such a Linux version, mounting an EFS file system using TLS will fail. 
+By default, when using the EFS mount helper with TLS, it enforces certificate hostname checking. The EFS mount helper uses the `stunnel` program for its TLS functionality. Please note that some versions of Linux do not include a version of `stunnel` that supports TLS features by default. When using such a Linux version, mounting an EFS file system using TLS will fail.
 
 Once you’ve installed the `amazon-efs-utils` package, to upgrade your system’s version of `stunnel`, see [Upgrading Stunnel](https://docs.aws.amazon.com/efs/latest/ug/using-amazon-efs-utils.html#upgrading-stunnel).
 
@@ -272,9 +273,9 @@ brew upgrade stunnel
 ## Install botocore
 
 `efs-utils` uses botocore to interact with other AWS services. Please note the package type from the above table and install
-botocore based on that info. If botocore is already installed and does not meet the minimum required version, 
+botocore based on that info. If botocore is already installed and does not meet the minimum required version,
 you can upgrade the botocore by following the [upgrade botocore section](#Upgrade-botocore).
- 
+
 - Download the `get-pip.py` script
 #### RPM
 ```bash
@@ -401,15 +402,15 @@ $ sudo bash -c "echo read-ahead-value-in-kb > /sys/class/bdi/0:$(stat -c '%d' ef
 
 ## Using botocore to retrieve mount target ip address when dns name cannot be resolved
 
-`efs-utils` now supports using botocore to retrieve mount target ip address when dns name cannot be resolved, e.g. 
+`efs-utils` now supports using botocore to retrieve mount target ip address when dns name cannot be resolved, e.g.
 when user is mounting a file system in another VPC. There are two prerequisites to use this feature:
 
 ### Step 1. Install botocore
 Follow [install botocore section](#Install-botocore)
 
 ### Step 2. Allow DescribeMountTargets and DescribeAvailabilityZones action in the IAM policy
-Allow the `elasticfilesystem:DescribeMountTargets` and `ec2:DescribeAvailabilityZones` action in your policy attached to 
-the iam role you attached to the instance, or the aws credentials configured on your instance. We recommend you attach 
+Allow the `elasticfilesystem:DescribeMountTargets` and `ec2:DescribeAvailabilityZones` action in your policy attached to
+the iam role you attached to the instance, or the aws credentials configured on your instance. We recommend you attach
 AWS managed policy `AmazonElasticFileSystemsUtils`.
 
 This feature will be enabled by default. To disable this feature:
@@ -418,11 +419,11 @@ This feature will be enabled by default. To disable this feature:
 sed -i "s/fall_back_to_mount_target_ip_address_enabled = true/fall_back_to_mount_target_ip_address_enabled = false/" /etc/amazon/efs/efs-utils.conf
 ```
 
-If you decide that you do not want to use this feature, but need to mount a cross-VPC file system, you can use the mounttargetip 
+If you decide that you do not want to use this feature, but need to mount a cross-VPC file system, you can use the mounttargetip
 option to do so, using the desired mount target ip address in the mount command.
 
 ## The way to access instance metadata
-`efs-utils` by default uses IMDSv2, which is a session-oriented method used to access instance metadata. If you don't want to use 
+`efs-utils` by default uses IMDSv2, which is a session-oriented method used to access instance metadata. If you don't want to use
 IMDSv2, you can disable the token fetching feature by running the following command:
 
 ```bash
@@ -430,7 +431,7 @@ sed -i "s/disable_fetch_ec2_metadata_token = false/disable_fetch_ec2_metadata_to
 ```
 
 ## Use the assumed profile credentials for IAM
-To authenticate with EFS using the system’s IAM identity of an awsprofile, add the `iam` option and pass the profile name to 
+To authenticate with EFS using the system’s IAM identity of an awsprofile, add the `iam` option and pass the profile name to
 `awsprofile` option. These options require the `tls` option.
 
 ```bash
@@ -439,18 +440,18 @@ $ sudo mount -t efs -o tls,iam,awsprofile=test-profile file-system-id efs-mount-
 
 To configure the named profile, see the [Named Profiles doc](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
 and [Support Config File Settings doc](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-settings)
-for more details. If the credentials (e.g. aws_access_key_id) are not configured in `/root/.aws/credentials` or `/root/.aws/config` 
-(note that the path prefix may vary based on the root path of sudo), efs-utils will use botocore to assume the named profile. 
+for more details. If the credentials (e.g. aws_access_key_id) are not configured in `/root/.aws/credentials` or `/root/.aws/config`
+(note that the path prefix may vary based on the root path of sudo), efs-utils will use botocore to assume the named profile.
 This will require botocore is pre-installed, please follow [install botocore section](#Install-botocore) to install botocore first.
 
 Normally you will need to configure your profile IAM policy to make the assume works. For example, if you want to perform a
-cross-account mounting, suppose you have established 
+cross-account mounting, suppose you have established
 [vpc-peering-connections](https://docs.aws.amazon.com/vpc/latest/peering/create-vpc-peering-connection.html) between your vpcs,
-next step you need to do is giving permission to account B so that it can assume a role in account A and then mount the file system 
-that belongs to account A. You can see 
+next step you need to do is giving permission to account B so that it can assume a role in account A and then mount the file system
+that belongs to account A. You can see
 [IAM doc](https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html) for more details.
 
-After the IAM identity is setup, you can configure your awsprofile credentials or config. You can refer to 
+After the IAM identity is setup, you can configure your awsprofile credentials or config. You can refer to
 [sdk settings](https://docs.aws.amazon.com/sdkref/latest/guide/settings-global.html). For example you can define
 the profile to use the credentials of profile `default` to assume role in account A by defining the `source_profile`.
 
@@ -483,7 +484,7 @@ Efs-Utils is able to enter FIPS mode when mounting your file system. To enable F
 ```bash
 sed -i "s/fips_mode_enabled = false/fips_mode_enabled = true/" /etc/amazon/efs/efs-utils.conf
 ```
-This will enable any potential API call from EFS-Utils to use FIPS endpoints and cause stunnel to enter FIPS mode 
+This will enable any potential API call from EFS-Utils to use FIPS endpoints and cause stunnel to enter FIPS mode
 
 Note: FIPS mode requires that the installed version of OpenSSL is compiled with FIPS.
 

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -268,6 +268,7 @@ SYSTEM_RELEASE_PATH = "/etc/system-release"
 OS_RELEASE_PATH = "/etc/os-release"
 MACOS_BIG_SUR_RELEASE = "macOS-11"
 MACOS_MONTEREY_RELEASE = "macOS-12"
+MACOS_VENTURA_RELEASE = "macOS-13"
 
 # Multiplier for max read ahead buffer size
 # Set default as 15 aligning with prior linux kernel 5.4
@@ -276,11 +277,11 @@ NFS_READAHEAD_CONFIG_PATH_FORMAT = "/sys/class/bdi/%s:%s/read_ahead_kb"
 NFS_READAHEAD_OPTIMIZE_LINUX_KERNEL_MIN_VERSION = [5, 4]
 
 # MacOS does not support the property of Socket SO_BINDTODEVICE in stunnel configuration
-SKIP_NO_SO_BINDTODEVICE_RELEASES = [MACOS_BIG_SUR_RELEASE, MACOS_MONTEREY_RELEASE]
+SKIP_NO_SO_BINDTODEVICE_RELEASES = [MACOS_BIG_SUR_RELEASE, MACOS_MONTEREY_RELEASE, MACOS_VENTURA_RELEASE]
 
 MAC_OS_PLATFORM_LIST = ["darwin"]
-# MacOS Versions : Monterey - 21.*, Big Sur - 20.*, Catalina - 19.*, Mojave - 18.*. Catalina and Mojave are not supported for now
-MAC_OS_SUPPORTED_VERSION_LIST = ["20", "21"]
+# MacOS Versions : Ventura - 22.*, Monterey - 21.*, Big Sur - 20.*, Catalina - 19.*, Mojave - 18.*. Catalina and Mojave are not supported for now
+MAC_OS_SUPPORTED_VERSION_LIST = ["20", "21", "22"]
 
 AWS_FIPS_ENDPOINT_CONFIG_ENV = "AWS_USE_FIPS_ENDPOINT"
 ECS_URI_ENV = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"


### PR DESCRIPTION
#158 

* Add support for macOS Ventura instances
* Minor updates to README (note: editor removed some trailing whitespace, can revert those incidental whitespace changes if necessary)

Tested mounting EFS volume on macOS instance launched from 13.0 [AMI](https://us-east-1.console.aws.amazon.com/ec2/home?region=us-east-1#ImageDetails:imageId=ami-0fe12b543f1354e5c) in `us-east-1`

```
# sw_vers
ProductName:            macOS
ProductVersion:         13.0
BuildVersion:           22A380

# cat mount.log
2023-01-27 01:26:27 GMT - INFO - Started TLS tunnel, pid: 51800
2023-01-27 01:26:27 GMT - INFO - Executing: "/sbin/mount_nfs -o nobrowse,noauto,noresvport,nfsvers=4.0,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,mountport=2049,port=20768 127.0.0.1:/ /<REDACTED>" with 15 sec time limit.
2023-01-27 01:26:27 GMT - INFO - Successfully mounted <REDACTED>.efs.us-east-1.amazonaws.com at /Volumes/<REDACTED>

# cat mount-watchdog.log
2023-01-27 01:34:53 GMT - INFO - amazon-efs-mount-watchdog, version 1.34.3, is enabled and started
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
