### PR TITLE
Add 'fsap' option as EFS-only option

### DIFF
--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -238,6 +238,7 @@ EFS_ONLY_OPTIONS = [
     "verify",
     "rolearn",
     "jwtpath",
+    "fsap"
 ]
 
 UNSUPPORTED_OPTIONS = ["capath"]


### PR DESCRIPTION
This adds the 'fsap' EFS mount option to the list of options to be ignored when mounting NFS filesystems. Without this, mounting an EFS access point fails on newer Linux distributions such as Ubuntu 22.04 which balks on unknown parameters to `mount.nfs4`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
