### PR TITLE
Check private key file size to skip generation

### DIFF
--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -2148,7 +2148,11 @@ def check_and_create_private_key(base_path=STATE_FILE_DIR):
 
     def generate_key():
         if os.path.isfile(key):
-            return
+            if os.path.getsize(key) == 0:
+                logging.info("Purging empty private key file")
+                os.remove(key)
+            else:
+                return
 
         cmd = (
             "openssl genpkey -algorithm RSA -out %s -pkeyopt rsa_keygen_bits:3072" % key


### PR DESCRIPTION
Nowadays, the private key generation function checks if the private key file exists. However, if the openssl command that generates the private key file is interrupted before writing the key, the file is there but empty. Such behaviour has been confirmed locally.

That causes the following issue (https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/683) when the EFS CSI driver pod is restarted. On the next start of the pod in the node, it doesn't generate the private key because of what is stated above.

With this change, if the file is empty it will be generated. No need for the workaround with the initContainer to delete the file.

#130 only did it for the watchdog file, we have the same code duplicated in `mount_efs/__init__.py`. Reusing the same
approach.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
