### PR TITLE
test: Fix pytest that failed since commit 3dd89ca

### DIFF
--- a/test/watchdog_test/test_check_if_using_old_version.py
+++ b/test/watchdog_test/test_check_if_using_old_version.py
@@ -35,6 +35,10 @@ def test_check_if_using_old_version_yum_works(mocker, caplog):
         return_value=GITHUB_VERSION,
     )
     mocker.patch("watchdog.EFSUtilsVersionChecker.update_version_check_file")
+    mocker.patch(
+        "watchdog.EFSUtilsVersionChecker.SHOULD_CHECK_AMZN_REPOS",
+        return_value=True,
+    )
 
     with caplog.at_level(logging.INFO):
         watchdog.EFSUtilsVersionChecker.check_if_using_old_version(OLD_VERSION)


### PR DESCRIPTION
Additional mocker patch added to test
'test_check_if_using_old_version_yum_works'
to make it pass again.

fixes: https://github.com/aws/efs-utils/issues/179

-----

*Issue #, if available:*
https://github.com/aws/efs-utils/issues/179

*Description of changes:*
The CircleCI project status is red (https://circleci.com/gh/aws/efs-utils), because all Python tests in the public circleci pipeline are in a failed state:
- https://app.circleci.com/pipelines/github/aws/efs-utils/237/workflows/574450d2-c225-4b9f-80f9-dfdcd153b530/jobs/4537
- https://app.circleci.com/pipelines/github/aws/efs-utils/237/workflows/574450d2-c225-4b9f-80f9-dfdcd153b530/jobs/4511
- https://app.circleci.com/pipelines/github/aws/efs-utils/237/workflows/574450d2-c225-4b9f-80f9-dfdcd153b530/jobs/4514
- https://app.circleci.com/pipelines/github/aws/efs-utils/237/workflows/574450d2-c225-4b9f-80f9-dfdcd153b530/jobs/4532
- https://app.circleci.com/pipelines/github/aws/efs-utils/237/workflows/574450d2-c225-4b9f-80f9-dfdcd153b530/jobs/4523
- https://app.circleci.com/pipelines/github/aws/efs-utils/237/workflows/574450d2-c225-4b9f-80f9-dfdcd153b530/jobs/4520

Reason is the assertion in `test_check_if_using_old_version.py`:
https://github.com/aws/efs-utils/blob/d5a0812c94f39336162381c6afb5d4eec7b418a0/test/watchdog_test/test_check_if_using_old_version.py#L39-L45

This code was introduced in commit https://github.com/aws/efs-utils/commit/3dd89caef058c744a419b6839416d726cdc5ab54

It uses `EFSUtilsVersionChecker.check_if_using_old_version` (https://github.com/aws/efs-utils/blob/master/src/watchdog/__init__.py#L382), 

`if EFSUtilsVersionChecker.SHOULD_CHECK_AMZN_REPOS:` in line 389 only checks for new versions in the repos if the test runs on AL. For all others, we run into the `try` statement in 407 and 412 (https://github.com/aws/efs-utils/blob/master/src/watchdog/__init__.py#L412) returns a warning:
https://github.com/aws/efs-utils/blob/d5a0812c94f39336162381c6afb5d4eec7b418a0/src/watchdog/__init__.py#L320-L328

that differs from the warning returned if its AL:
https://github.com/aws/efs-utils/blob/d5a0812c94f39336162381c6afb5d4eec7b418a0/src/watchdog/__init__.py#L309-L317

The circleci based test run in  `python:3.y.z` container images and will therefore always trigger the github version check.

By adding an additional mocker patch to enforce the AL behavior like this:

```
    mocker.patch(
        "watchdog.EFSUtilsVersionChecker.SHOULD_CHECK_AMZN_REPOS",
        return_value=True,
    )
```

after
https://github.com/aws/efs-utils/blob/d5a0812c94f39336162381c6afb5d4eec7b418a0/test/watchdog_test/test_check_if_using_old_version.py#L28-L38

The actual python based unittests go back to green based on local tests (`circleci local execute python3_9`, `circleci local execute python3_8`, `circleci local execute python3_7`, `circleci local execute python3_6`, `circleci local execute python3_5`, `circleci local execute python3_4`), `test/watchdog_test/test_check_if_using_old_version.py::test_check_if_using_old_version_yum_works PASSED` on all versions, no errors anymore:

```
pytest
============================= test session starts ==============================
platform linux -- Python 3.9.13, pytest-4.6.7, py-1.10.0, pluggy-0.13.0 -- /root/efs-utils-virtualenv/bin/python
[...]
Required test coverage of 80% reached. Total coverage: 84.89%
========================= 557 passed in 18.06 seconds ==========================


pytest
============================= test session starts ==============================
platform linux -- Python 3.8.13, pytest-4.6.7, py-1.10.0, pluggy-0.13.0 -- /root/efs-utils-virtualenv/bin/python
[...]
Required test coverage of 80% reached. Total coverage: 84.89%
========================= 557 passed in 19.16 seconds ==========================


pytest
============================= test session starts ==============================
platform linux -- Python 3.7.13, pytest-4.6.7, py-1.10.0, pluggy-0.13.0 -- /root/efs-utils-virtualenv/bin/python
[...]
Required test coverage of 80% reached. Total coverage: 84.81%
========================= 557 passed in 17.75 seconds ==========================


pytest
============================= test session starts ==============================
platform linux -- Python 3.6.15, pytest-4.6.7, py-1.10.0, pluggy-0.13.0 -- /root/efs-utils-virtualenv/bin/python
[...]
Required test coverage of 80% reached. Total coverage: 84.81%
==================== 555 passed, 2 skipped in 16.96 seconds ====================


pytest
============================= test session starts ==============================
platform linux -- Python 3.5.10, pytest-4.6.7, py-1.10.0, pluggy-0.13.0 -- /root/efs-utils-virtualenv/bin/python
[...]
Required test coverage of 80% reached. Total coverage: 84.67%
==================== 554 passed, 3 skipped in 16.08 seconds ====================


pytest
============================= test session starts ==============================
platform linux -- Python 3.4.10, pytest-4.6.7, py-1.10.0, pluggy-0.13.0 -- /root/efs-utils-virtualenv/bin/python
[...]
Required test coverage of 80% reached. Total coverage: 84.43%
==================== 553 passed, 4 skipped in 17.80 seconds ====================
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
