### PR TITLE
test: Fix git related error in 'build-rpm', add rocky9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,11 +56,15 @@ commands:
             mount.efs --version
   build-rpm:
     steps:
-      - checkout
       - run:
           name: Install dependencies
           command: |
-            yum -y install rpm-build make systemd
+            yum -y install rpm-build make systemd git
+      - run:
+          name: Add local build repo as safe git directory
+          command: |
+            git config --global --add safe.directory /tmp/_circleci_local_build_repo
+      - checkout
       - run:
           name: Build RPM
           command: |
@@ -216,6 +220,9 @@ workflows:
       - build-rpm-package:
           name: rocky8
           image: rockylinux/rockylinux:8
+      - build-rpm-package:
+          name: rocky9
+          image: rockylinux/rockylinux:9
       - build-rpm-package:
           name: amazon-linux-latest
           image: amazonlinux:latest


### PR DESCRIPTION
Fix a git not found warning/error and add rocky9
to the circleci build workflow.

fixes: https://github.com/aws/efs-utils/issues/181

-----

*Issue #, if available:*
https://github.com/aws/efs-utils/issues/181

*Description of changes:*
PR consists for two topics, first (and simplest) is to add Rocky Linux 9 to the circleci build workflow.

Second topic is that locally executed test with Rocky Linux 8 (`circleci local execute rocky8`) with circleci (version 0.1.29041+68d2c20) throws:

```
Error: /bin/sh: git: command not found
```

followed by (because of missing source code):
```
make: *** No rule to make target 'rpm'.  Stop.
Error: 
Exited with code exit status 2

Step failed
Error: runner failed (exited with 101)
Task failed
Error: task failed
```

Assumption why there is only a warning in https://app.circleci.com/pipelines/github/aws/efs-utils/237/workflows/574450d2-c225-4b9f-80f9-dfdcd153b530/jobs/4504/parallel-runs/0/steps/0-101: Older CircleCI version or if you run the tests online and not locally, seem to ship a build-in `git` binary as fallback, which cause a warning and recommendation to switch to a container image that includes `git` already.
> Either git or ssh (required by git to clone through SSH) is not installed in the image. Falling back to CircleCI's native git client but the behavior may be different from official git. If this is an issue, please use an image that has official git and ssh installed.

Best way to mitigate the warning and to fix the error seems to add `git` to the list of packages to be installed inside the container, ensure that `/tmp/_circleci_local_build_repo` is recognized by git as safe directory (cause `Error: fatal: detected dubious ownership in repository` otherwise) and changing the `build-rpm` steps that package install and safe directory command running before `checkout`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Successfully tested with all builds that rely on `build-rpm-package`:
- rocky8
- centos7
- amazon-linux-latest
- amazon-linux-2
- amazon-linux
- fedora-latest
- fedora28
- fedora29
- fedora30
- fedora31
- fedora32
- fedora33
- fedora34
- fedora35
- fedora36
- centos-latest
- centos8