### PR TITLE
test: Change repo urls in eol debian9 build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,6 @@ commands:
           path: build
   build-deb:
     steps:
-      - checkout
       - run:
           name: Repo update
           command: |
@@ -41,7 +40,12 @@ commands:
       - run:
           name: Install dependencies
           command: |
-            apt-get -y install binutils
+            apt-get -y install binutils git
+      - run:
+          name: Add local build repo as safe git directory
+          command: |
+            git config --global --add safe.directory /tmp/_circleci_local_build_repo
+      - checkout
       - run:
           name: Build DEB
           command: |
@@ -112,6 +116,14 @@ commands:
         command: |
           sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
           sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+  build-debian-eol-repo:
+    steps:
+      - run:
+          name: change repo url to archive.debian.org and remove updates repo for EOL versions
+          command: |
+            sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
+            sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list
+            sed -i '/stretch-updates/d' /etc/apt/sources.list
 jobs:
   test:
     parameters:
@@ -159,6 +171,16 @@ jobs:
     steps:
       - build-centos-repo
       - build-rpm
+  build-debian-eol-rpm-package:
+    parameters:
+      image:
+        type: string
+    executor:
+      name: linux
+      image: << parameters.image >>
+    steps:
+      - build-debian-eol-repo
+      - build-deb
 workflows:
   workflow:
     jobs:
@@ -195,7 +217,7 @@ workflows:
       - build-deb-package:
           name: ubuntu22
           image: ubuntu:22.04
-      - build-deb-package:
+      - build-debian-eol-rpm-package:
           name: debian9
           image: debian:stretch
       - build-deb-package:


### PR DESCRIPTION
Debian 9 is EOL and entered ELTS, which is not part of the Debian project. Repository URLs changed from deb.archive.org / security.debian.org to archive.debian.org, also 'stretch-updates' is not available anymore and need to removed.

This commit changes the urls and removes 'updates' before installing packages. It also ensures that 'git' is installed as dependency and the temporary build folder added as safe git directory.

fixes: https://github.com/aws/efs-utils/issues/183

-----

*Issue #, if available:*
https://github.com/aws/efs-utils/issues/183

*Description of changes:*
Pipeline still shows as failed because the debian9 build fails, the PR contains a workaround, alternative approach would be to remove EOL version from the circleci config. 

The git related fix is similar to https://github.com/aws/efs-utils/pull/182 / https://github.com/aws/efs-utils/issues/181.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
