### PR TITLE
Remove /usr/bin/env from systemd unit

### DIFF
--- a/dist/amazon-efs-mount-watchdog.service
+++ b/dist/amazon-efs-mount-watchdog.service
@@ -12,7 +12,7 @@ Before=remote-fs-pre.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/env amazon-efs-mount-watchdog
+ExecStart=/usr/bin/amazon-efs-mount-watchdog
 KillMode=process
 Restart=on-failure
 RestartSec=15s


### PR DESCRIPTION
*Issue #, if available:*

No issue currently, but I can make one if it's required.

*Description of changes:*

Calling the watchdog with /usr/bin/env makes it difficult to confine the watchdog daemon with SELinux. No environment variables exist in the systemd unit file right now, so /usr/bin/env should not be necessary.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
