### PR TITLE
Fix utcnow() deprecation warning

### DIFF
--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -238,7 +238,7 @@ EFS_ONLY_OPTIONS = [
     "verify",
     "rolearn",
     "jwtpath",
-    "fsap"
+    "fsap",
 ]
 
 UNSUPPORTED_OPTIONS = ["capath"]
@@ -1761,7 +1761,6 @@ def get_nfs_mount_options(options):
 
 
 def mount_nfs(config, dns_name, path, mountpoint, options, fallback_ip_address=None):
-
     if "tls" in options:
         mount_path = "127.0.0.1:%s" % path
     elif fallback_ip_address:
@@ -1827,7 +1826,7 @@ def call_nfs_mount_command_with_retry_succeed(
 ):
     def backoff_function(i):
         """Backoff exponentially and add a constant 0-1 second jitter"""
-        return (1.5 ** i) + random.random()
+        return (1.5**i) + random.random()
 
     if not get_boolean_config_item_value(
         config, CONFIG_SECTION, "retry_nfs_mount_command", default_value=True
@@ -2090,12 +2089,15 @@ def create_certificate(
     not_before = get_certificate_timestamp(current_time, minutes=-NOT_BEFORE_MINS)
     not_after = get_certificate_timestamp(current_time, hours=NOT_AFTER_HOURS)
 
-    cmd = "openssl ca -startdate %s -enddate %s -selfsign -batch -notext -config %s -in %s -out %s" % (
-        not_before,
-        not_after,
-        certificate_config,
-        certificate_signing_request,
-        certificate,
+    cmd = (
+        "openssl ca -startdate %s -enddate %s -selfsign -batch -notext -config %s -in %s -out %s"
+        % (
+            not_before,
+            not_after,
+            certificate_config,
+            certificate_signing_request,
+            certificate,
+        )
     )
     subprocess_call(cmd, "Failed to create self-signed client-side certificate")
     return current_time.strftime(CERT_DATETIME_FORMAT)
@@ -2333,7 +2335,7 @@ def get_utc_now():
     """
     Wrapped for patching purposes in unit tests
     """
-    return datetime.utcnow()
+    return datetime.now(datetime.UTC)
 
 
 def assert_root():
@@ -3669,7 +3671,6 @@ def handle_general_botocore_exceptions(error):
 # NFS client might see a throughput drop in kernel 5.4+, especially for sequential read.
 # To fix the issue, below function will modify read_ahead_kb to 15 * rsize (1MB by default) after mount.
 def optimize_readahead_window(mountpoint, options, config):
-
     if not should_revise_readahead(config):
         return
 

--- a/src/watchdog/__init__.py
+++ b/src/watchdog/__init__.py
@@ -47,7 +47,8 @@ try:
 except ImportError:
     from urllib import urlencode
 
-    from urllib2 import HTTPError, HTTPHandler, Request, URLError, build_opener, urlopen
+    from urllib2 import (HTTPError, HTTPHandler, Request, URLError,
+                         build_opener, urlopen)
 
 
 AMAZON_LINUX_2_RELEASE_ID = "Amazon Linux release 2 (Karoo)"
@@ -2229,7 +2230,7 @@ def get_utc_now():
     """
     Wrapped for patching purposes in unit tests
     """
-    return datetime.utcnow()
+    return datetime.now(datetime.UTC)
 
 
 def check_process_name(pid):

--- a/test/mount_efs_test/test_write_tls_tunnel_state_file.py
+++ b/test/mount_efs_test/test_write_tls_tunnel_state_file.py
@@ -27,7 +27,7 @@ def test_write_tls_tunnel_state_file_netns(tmpdir):
 
     mount_point = "/home/user/foo/mount"
 
-    current_time = datetime.utcnow()
+    current_time = datetime.now(datetime.UTC)
     cert_creation_time = current_time.strftime(DATETIME_FORMAT)
 
     cert_details = {
@@ -85,7 +85,7 @@ def test_write_tls_tunnel_state_file(tmpdir):
 
     mount_point = "/home/user/foo/mount"
 
-    current_time = datetime.utcnow()
+    current_time = datetime.now(datetime.UTC)
     cert_creation_time = current_time.strftime(DATETIME_FORMAT)
 
     cert_details = {

--- a/test/watchdog_test/test_check_efs_mounts.py
+++ b/test/watchdog_test/test_check_efs_mounts.py
@@ -28,7 +28,7 @@ STATE = {
     "pid": PID,
     "commonName": "deadbeef.com",
     "certificate": "/tmp/foobar",
-    "certificateCreationTime": datetime.utcnow().strftime(
+    "certificateCreationTime": datetime.now(datetime.UTC).strftime(
         watchdog.CERT_DATETIME_FORMAT
     ),
     "mountStateDir": "fs-deadbeef.mount.dir.12345",

--- a/test/watchdog_test/test_check_if_using_old_version.py
+++ b/test/watchdog_test/test_check_if_using_old_version.py
@@ -10,7 +10,6 @@ import tempfile
 from datetime import date, datetime
 
 import pytest
-
 import watchdog
 
 try:
@@ -88,7 +87,7 @@ def test_check_if_using_old_version_yum_github_fail(mocker, caplog):
 
 
 def test_get_last_version_check_date(mocker, tmp_path):
-    current_time_str = datetime.utcnow().strftime(CERT_DATETIME_FORMAT)
+    current_time_str = datetime.now(datetime.UTC).strftime(CERT_DATETIME_FORMAT)
     dictionary = {
         "time": current_time_str,
     }
@@ -107,7 +106,7 @@ def test_get_last_version_check_date(mocker, tmp_path):
 
 def test_get_last_version_check_bad_format(mocker, tmp_path):
     """Make sure that watchdog does not crash if the version check file does not have a format we expect"""
-    current_time_str = datetime.utcnow().strftime(CERT_DATETIME_FORMAT)
+    current_time_str = datetime.now(datetime.UTC).strftime(CERT_DATETIME_FORMAT)
     dictionary = {
         "bad_key": current_time_str,
     }
@@ -135,7 +134,7 @@ def test_version_check_ready(mocker):
 
 def test_update_version_check_file(mocker, tmp_path):
     """Write current time into the version check file"""
-    current_time = datetime.utcnow()
+    current_time = datetime.now(datetime.UTC)
     mocker.patch("watchdog.get_utc_now", return_value=current_time)
     version_check_file = tempfile.NamedTemporaryFile(mode="w+", dir=str(tmp_path))
     mocker.patch("os.path.join", return_value=version_check_file.name)

--- a/test/watchdog_test/test_clean_up_previous_stunnel_pids.py
+++ b/test/watchdog_test/test_clean_up_previous_stunnel_pids.py
@@ -19,7 +19,7 @@ STATE = {
     "pid": PID,
     "commonName": "deadbeef.com",
     "certificate": "/tmp/foobar",
-    "certificateCreationTime": datetime.utcnow().strftime(
+    "certificateCreationTime": datetime.now(datetime.UTC).strftime(
         watchdog.CERT_DATETIME_FORMAT
     ),
     "mountStateDir": "fs-deadbeef.mount.dir.12345",

--- a/test/watchdog_test/test_refresh_self_signed_certificate.py
+++ b/test/watchdog_test/test_refresh_self_signed_certificate.py
@@ -9,9 +9,8 @@ import logging
 import os
 from datetime import datetime, timedelta
 
-import pytest
-
 import mount_efs
+import pytest
 import watchdog
 
 try:
@@ -472,7 +471,9 @@ def test_refresh_self_signed_certificate_send_sighup(mocker, tmpdir, caplog):
 
     config = _get_config()
     pk_path = _get_mock_private_key_path(mocker, tmpdir)
-    four_hours_back = (datetime.utcnow() - timedelta(hours=4)).strftime(DT_PATTERN)
+    four_hours_back = (datetime.now(datetime.UTC) - timedelta(hours=4)).strftime(
+        DT_PATTERN
+    )
     tls_dict = watchdog.tls_paths_dictionary(MOUNT_NAME, str(tmpdir))
     state = _create_certificate_and_state(
         tls_dict, str(tmpdir), pk_path, four_hours_back, ap_id=AP_ID
@@ -494,7 +495,9 @@ def test_refresh_self_signed_certificate_pid_not_running(mocker, tmpdir, caplog)
 
     config = _get_config()
     pk_path = _get_mock_private_key_path(mocker, tmpdir)
-    four_hours_back = (datetime.utcnow() - timedelta(hours=4)).strftime(DT_PATTERN)
+    four_hours_back = (datetime.now(datetime.UTC) - timedelta(hours=4)).strftime(
+        DT_PATTERN
+    )
     tls_dict = watchdog.tls_paths_dictionary(MOUNT_NAME, str(tmpdir))
     state = _create_certificate_and_state(
         tls_dict, str(tmpdir), pk_path, four_hours_back, False, ap_id=AP_ID


### PR DESCRIPTION
Fedora 39 has Python 3.12 and running the efs-utils watchdog causes the system journal to be filled with deprecation warnings:

    /usr/bin/amazon-efs-mount-watchdog:2009: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version.

Fixes: aws/efs-utils#187
