### PR TITLE
Add support for macOS Sonoma based EC2 Mac instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The `efs-utils` package has been verified against the following MacOS distributi
 | MacOS Big Sur  | `launchd` |
 | MacOS Monterey | `launchd` |
 | MacOS Ventura  | `launchd` |
+| MacOS Sonoma   | `launchd` |
 
 ## README contents
   - [Prerequisites](#prerequisites)
@@ -158,11 +159,11 @@ $ ./build-deb.sh
 $ sudo apt-get -y install ./build/amazon-efs-utils*deb
 ```
 
-### On MacOS Big Sur, macOS Monterey and macOS Ventura distribution
+### On macOS Big Sur, Monterey, Ventura or Sonoma
 
-For EC2 Mac instances running macOS Big Sur, macOS Monterey and macOS Ventura, you can install amazon-efs-utils from the 
+For EC2 Mac instances running macOS Big Sur, Monterey, Ventura, or Sonoma, you can install amazon-efs-utils from the 
 [homebrew-aws](https://github.com/aws/homebrew-aws) respository. **Note that this will ONLY work on EC2 instances
-running macOS Big Sur, macOS Monterey and macOS Ventura, not local Mac computers.**
+running macOS Big Sur, Monterey, Ventura or Sonoma and not on local Apple mac hardware.**
 ```bash
 brew install amazon-efs-utils
 ```

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -272,6 +272,7 @@ OS_RELEASE_PATH = "/etc/os-release"
 MACOS_BIG_SUR_RELEASE = "macOS-11"
 MACOS_MONTEREY_RELEASE = "macOS-12"
 MACOS_VENTURA_RELEASE = "macOS-13"
+MACOS_SONOMA_RELEASE = "macOS-14"
 
 
 # Multiplier for max read ahead buffer size
@@ -288,8 +289,8 @@ SKIP_NO_SO_BINDTODEVICE_RELEASES = [
 ]
 
 MAC_OS_PLATFORM_LIST = ["darwin"]
-# MacOS Versions : Ventura - 22.*, Monterey - 21.*, Big Sur - 20.*, Catalina - 19.*, Mojave - 18.*. Catalina and Mojave are not supported for now
-MAC_OS_SUPPORTED_VERSION_LIST = ["20", "21", "22"]
+# MacOS Versions : Sonoma - 23.*, Ventura - 22.*, Monterey - 21.*, Big Sur - 20.*, Catalina - 19.*, Mojave - 18.*. Catalina and Mojave are not supported for now
+MAC_OS_SUPPORTED_VERSION_LIST = ["20", "21", "22", "23"]
 
 AWS_FIPS_ENDPOINT_CONFIG_ENV = "AWS_USE_FIPS_ENDPOINT"
 ECS_URI_ENV = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add support for macOS Sonoma based EC2 Mac instances

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
