### PR TITLE
Fix utcnow() deprecation warning

### DIFF
--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -47,7 +47,7 @@ import sys
 import threading
 import time
 from contextlib import contextmanager
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from logging.handlers import RotatingFileHandler
 
 try:
@@ -2337,7 +2337,7 @@ def get_utc_now():
     """
     Wrapped for patching purposes in unit tests
     """
-    return datetime.utcnow()
+    return datetime.now(timezone.utc)
 
 
 def assert_root():

--- a/src/watchdog/__init__.py
+++ b/src/watchdog/__init__.py
@@ -25,7 +25,7 @@ import sys
 import time
 from collections import namedtuple
 from contextlib import contextmanager
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from logging.handlers import RotatingFileHandler
 from signal import SIGHUP, SIGKILL, SIGTERM
 
@@ -2235,7 +2235,7 @@ def get_utc_now():
     """
     Wrapped for patching purposes in unit tests
     """
-    return datetime.utcnow()
+    return datetime.now(timezone.utc)
 
 
 def check_process_name(pid):


### PR DESCRIPTION
## Issue #, if available:

#187

## Description of changes:

Replaces `datetime.utcnow()` with `datetime.now(timezone.utc)` to avoid deprecation warnings in Python 3.12.

## By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Agreed! ✅
