### PR TITLE
Add crossaccount AZ-mapping mount option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,13 @@ To mount file system to the mount target in specific availability zone (e.g. us-
 $ sudo mount -t efs -o az=az-name file-system-id efs-mount-point/
 ```
 
+**Note: The [prequisites in the crossaccount section below](#crossaccount-option-prerequisites) must be completed before using the crossaccount option.**
+
+To mount the filesystem mount target in the same physical availability zone ID (e.g. use1-az1) as the client instance over cross-AWS-account mounts, run:
+```
+$ sudo mount -t efs -o crossaccount file-system-id efs-mount-point/
+```
+
 To mount over TLS, simply add the `tls` option:
 
 ```bash
@@ -252,6 +259,28 @@ man mount.efs
 ```
 
 or refer to the [documentation](https://docs.aws.amazon.com/efs/latest/ug/using-amazon-efs-utils.html).
+
+#### crossaccount Option Prerequisites
+
+The crossaccount mount option ensures that the client instance Availability Zone ID (e.g. use1-az1) is the same as the EFS mount target Availability Zone ID for cross-AWS-account mounts (e.g. if the client instance is in Account A while the EFS instance is in Account B). 
+
+Given a client instance in Account A/VPC A and an EFS instance in Account B/VPC B, the following prerequisites must be completed prior to using the crossaccount option:
+- Cross-VPC Communication:
+  - Create a VPC Peering relationship between VPC A & VPC B. Documentation to create the peering relationship can be found [here](https://docs.aws.amazon.com/vpc/latest/peering/create-vpc-peering-connection.html).
+  - Configure VPC route tables to send/receive traffic. Documentation can be found [here](https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-routing.html).
+  - Create subnet in VPC B in the Availability Zone of the Account A client instance if it does not exist already.
+  - Create an EFS Mount Target in each of the Availability Zones from the above step in VPC B if they do not exist already.
+  - Attach a VPC Security Group to each of the EFS Mount Targets which allow inbound NFS access from VPC A’s CIDR block.
+- Route 53 Setup:
+  - For a mount target A in <availability-zone-id>, create a Route 53 Hosted Zone for the domain <availability-zone-id>.<file-system-id>.efs.<aws-region>.amazonaws.com.
+  - Then, add an A record in the Hosted Zone which resolves to mount target A's IP Address. Leave the subdomain blank.
+
+
+Once the above steps have been completed, to mount the filesystem mount target in the same physical availability zone ID (e.g. use1-az1) as the client instance over cross-AWS-account mounts, run:
+```
+$ sudo mount -t efs -o crossaccount file-system-id efs-mount-point/
+```
+
 
 ### MacOS 
 

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -117,6 +117,7 @@ FALLBACK_TO_MOUNT_TARGET_IP_ADDRESS_ITEM = (
     "fall_back_to_mount_target_ip_address_enabled"
 )
 INSTANCE_IDENTITY = None
+INSTANCE_AZ_ID_METADATA = None
 RETRYABLE_ERRORS = ["reset by peer"]
 OPTIMIZE_READAHEAD_ITEM = "optimize_readahead"
 
@@ -198,6 +199,9 @@ INSTANCE_METADATA_TOKEN_URL = "http://169.254.169.254/latest/api/token"
 INSTANCE_METADATA_SERVICE_URL = (
     "http://169.254.169.254/latest/dynamic/instance-identity/document/"
 )
+INSTANCE_METADATA_SERVICE_AZ_ID_URL = (
+    "http://169.254.169.254/latest/meta-data/placement/availability-zone-id"
+)
 INSTANCE_IAM_URL = "http://169.254.169.254/latest/meta-data/iam/security-credentials/"
 NAMED_PROFILE_HELP_URL = (
     "https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html"
@@ -239,6 +243,7 @@ EFS_ONLY_OPTIONS = [
     "rolearn",
     "jwtpath",
     "fsap",
+    "crossaccount"
 ]
 
 UNSUPPORTED_OPTIONS = ["capath"]
@@ -297,6 +302,10 @@ AWS_FIPS_ENDPOINT_CONFIG_ENV = "AWS_USE_FIPS_ENDPOINT"
 ECS_URI_ENV = "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"
 WEB_IDENTITY_ROLE_ARN_ENV = "AWS_ROLE_ARN"
 WEB_IDENTITY_TOKEN_FILE_ENV = "AWS_WEB_IDENTITY_TOKEN_FILE"
+
+ECS_FARGATE_TASK_METADATA_ENDPOINT_ENV = "ECS_CONTAINER_METADATA_URI_V4"
+ECS_FARGATE_TASK_METADATA_ENDPOINT_URL_EXTENSION = "/task"
+ECS_FARGATE_CLIENT_IDENTIFIER = "ecs.fargate"
 
 
 def errcheck(ret, func, args):
@@ -426,6 +435,90 @@ def get_az_from_instance_metadata(config):
 
     return instance_identity
 
+
+def get_az_id_from_instance_metadata(config, options):
+    az_id = get_az_id_info_from_instance_metadata(
+        config,
+        options
+    )
+
+    if not az_id:
+        raise Exception("Cannot retrieve az-id from instance_metadata")
+
+    return az_id
+
+# Creating a separate function for AZ-ID for maintainability. It will be overly complex 
+# if get_instance_identity_info_from_instance_metadata returns multiple different formats
+# & alters url depending on input
+def get_az_id_info_from_instance_metadata(config, options):
+    logging.debug("Retrieve availability-zone-id from instance metadata")
+    instance_az_id_url = get_instance_az_id_metadata_url(config)
+    metadata_unsuccessful_resp = (
+        "Unsuccessful retrieval of metadata at %s." % instance_az_id_url
+    )
+    metadata_url_error_msg = (
+        "Unable to reach %s to retrieve instance metadata."
+        % instance_az_id_url
+    )
+
+    global INSTANCE_AZ_ID_METADATA
+    if INSTANCE_AZ_ID_METADATA:
+        logging.debug(
+            "Instance az_id already retrieved in previous call, use the cached values."
+        )
+        az_id_metadata = INSTANCE_AZ_ID_METADATA
+    else:
+        az_id_metadata = url_request_helper(
+            config,
+            instance_az_id_url,
+            metadata_unsuccessful_resp,
+            metadata_url_error_msg,
+        )
+        INSTANCE_AZ_ID_METADATA = az_id_metadata
+
+    if az_id_metadata:
+        return get_az_id_helper(config, options, az_id_metadata)
+    
+    return None
+
+def get_instance_az_id_metadata_url(config):
+    instance_az_id_url = INSTANCE_METADATA_SERVICE_AZ_ID_URL
+    if is_ecs_fargate_client(config):
+        # ECS-Fargate Metadata Endpoint must be used for ECS-Fargate clients.
+        logging.debug("ECS-Fargate client detected, use ECS-Fargate Metadata Endpoint")
+        try:
+            instance_az_id_url = os.getenv(ECS_FARGATE_TASK_METADATA_ENDPOINT_ENV)+ECS_FARGATE_TASK_METADATA_ENDPOINT_URL_EXTENSION
+        except Exception as e:
+            logging.warning("Unable to parse ECS-Fargate Metadata Endpoint: %s", e)
+            instance_az_id_url = None
+    return instance_az_id_url
+
+def is_ecs_fargate_client(config):
+    client_info = get_client_info(config)
+    if client_info and client_info.get("source") == ECS_FARGATE_CLIENT_IDENTIFIER:
+        return True
+    return False
+
+def get_az_id_helper(config, options, az_id_metadata):
+    if is_ecs_fargate_client(config):
+        try:
+            property = "AvailabilityZone"
+            az_name = az_id_metadata[property]
+            ec2_client = get_botocore_client(config, "ec2", options)
+            return get_az_id_by_az_name(ec2_client, az_name)
+        except KeyError as e:
+            logging.warning(
+                "%s not present in %s: %s" % (property, az_id_metadata, e)
+            )
+        except TypeError as e:
+            logging.warning(
+                "response %s is not a json object: %s" % (az_id_metadata, e)
+            )
+        return None
+
+    return az_id_metadata
+    
+    
 
 def get_instance_identity_info_from_instance_metadata(config, property):
     logging.debug("Retrieve property %s from instance metadata", property)
@@ -2415,7 +2508,13 @@ def get_dns_name_and_fallback_mount_target_ip_address(config, fs_id, options):
 
     expected_replacement_field_ct = 1
 
-    if "{az}" in dns_name_format:
+    if options and "crossaccount" in options:
+            if "{az}" not in dns_name_format:
+                raise ValueError("DNS name format must include {az} for cross account mount")
+            az = get_az_id_from_instance_metadata(config, options)
+            expected_replacement_field_ct += 1
+            format_args["az"] = az
+    elif "{az}" in dns_name_format:
         az = options.get("az")
         if az:
             expected_replacement_field_ct += 1
@@ -2491,6 +2590,10 @@ def get_dns_name_and_fallback_mount_target_ip_address(config, fs_id, options):
 
 
 def get_fallback_mount_target_ip_address(config, options, fs_id, dns_name):
+    if options and "crossaccount" in options:
+        fallback_message = "Fallback to mount target ip address feature is not available when the crossaccount option is used."
+        raise FallbackException(fallback_message)
+
     fall_back_to_ip_address_enabled = (
         check_if_fall_back_to_mount_target_ip_address_is_enabled(config)
     )

--- a/test/mount_efs_test/test_get_dns_name_and_fallback_mount_target_ip_address.py
+++ b/test/mount_efs_test/test_get_dns_name_and_fallback_mount_target_ip_address.py
@@ -34,6 +34,7 @@ SPECIAL_REGIONS = ["cn-north-1", "cn-northwest-1", "us-iso-east-1", "us-isob-eas
 DEFAULT_NFS_OPTIONS = {}
 OPTIONS_WITH_AZ = {"az": DEFAULT_AZ}
 OPTIONS_WITH_IP = {"mounttargetip": IP_ADDRESS}
+OPTIONS_WITH_CROSSACCOUNT = {"crossaccount": None}
 MOCK_EFS_AGENT = "fake-efs-client"
 MOCK_EC2_AGENT = "fake-ec2-client"
 
@@ -117,6 +118,23 @@ def test_get_dns_name_with_ip_in_options(mocker):
     assert "%s.efs.%s.amazonaws.com" % (FS_ID, DEFAULT_REGION) == dns_name
     assert IP_ADDRESS == ip_address
     utils.assert_called(ip_address_connect_mock)
+
+
+def test_get_dns_name_with_crossaccount_in_options(mocker):
+    config = _get_mock_config("{az}.{fs_id}.efs.{region}.amazonaws.com")
+
+    get_az_id_mock = mocker.patch(
+        "mount_efs.get_az_id_from_instance_metadata", return_value=DEFAULT_AZ_ID
+    )
+
+    dns_name, ip_address = mount_efs.get_dns_name_and_fallback_mount_target_ip_address(
+        config, FS_ID, OPTIONS_WITH_CROSSACCOUNT
+    )
+
+    assert (
+        "%s.%s.efs.%s.amazonaws.com" % (DEFAULT_AZ_ID, FS_ID, DEFAULT_REGION) == dns_name
+    )
+    utils.assert_called(get_az_id_mock)
 
 
 def test_get_dns_name_suffix_hardcoded():

--- a/test/mount_efs_test/test_get_fallback_mount_target_ip_address.py
+++ b/test/mount_efs_test/test_get_fallback_mount_target_ip_address.py
@@ -33,6 +33,7 @@ SPECIAL_REGION_DNS_DICT = {
 SPECIAL_REGIONS = ["cn-north-1", "cn-northwest-1", "us-iso-east-1", "us-isob-east-1"]
 DEFAULT_NFS_OPTIONS = {}
 OPTIONS_WITH_AZ = {"az": DEFAULT_AZ}
+OPTIONS_WITH_CROSSACCOUNT = {"crossaccount": None}
 MOCK_EFS_AGENT = "fake-efs-client"
 MOCK_EC2_AGENT = "fake-ec2-client"
 
@@ -230,6 +231,30 @@ def test_get_fall_back_ip_address_feature_not_enabled(mocker):
     assert "not enabled" in str(excinfo)
 
     utils.assert_called(check_fallback_enabled_mock)
+    utils.assert_not_called(get_fallback_mount_target_ip_mock)
+    utils.assert_not_called(check_ip_resolve_mock)
+
+
+def test_get_fall_back_ip_address_when_crossaccount_enabled(mocker):
+    """
+    When the crossacount feature is enabled this should throw an Exception
+    """
+    config = _get_mock_config()
+
+    get_fallback_mount_target_ip_mock = mocker.patch(
+        "mount_efs.get_fallback_mount_target_ip_address_helper"
+    )
+    check_ip_resolve_mock = mocker.patch(
+        "mount_efs.mount_target_ip_address_can_be_resolved"
+    )
+
+    with pytest.raises(mount_efs.FallbackException) as excinfo:
+        mount_efs.get_fallback_mount_target_ip_address(
+            config, OPTIONS_WITH_CROSSACCOUNT, FS_ID, DNS_NAME
+        )
+
+    assert "crossaccount option" in str(excinfo)
+
     utils.assert_not_called(get_fallback_mount_target_ip_mock)
     utils.assert_not_called(check_ip_resolve_mock)
 

--- a/test/mount_efs_test/test_get_instance_az_id.py
+++ b/test/mount_efs_test/test_get_instance_az_id.py
@@ -1,0 +1,289 @@
+# Copyright 2017-2018 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the MIT License. See the LICENSE accompanying this file
+# for the specific language governing permissions and limitations under
+# the License.
+
+import json
+import socket
+
+import pytest
+
+import mount_efs
+
+from .. import utils
+
+try:
+    import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+
+try:
+    from urllib2 import HTTPError, URLError
+except ImportError:
+    from urllib.error import HTTPError, URLError
+
+FARGATE_AZ_ID_ENDPOINT = "http://169.254.170.2"+mount_efs.ECS_FARGATE_TASK_METADATA_ENDPOINT_URL_EXTENSION
+INSTANCE_AZ_ID = "use1-az1"
+INSTANCE_DATA_ECS_FARGATE = {
+  "Cluster": "arn:aws:ecs:us-east-1:123456789012:cluster/clusterName",
+  "TaskARN": "arn:aws:ecs:us-east-1:123456789012:task/MyEmptyCluster/bfa2636268144d039771334145e490c5",
+  "Family": "sample-fargate",
+  "Revision": "5",
+  "DesiredStatus": "RUNNING",
+  "KnownStatus": "RUNNING",
+  "Limits": {
+    "CPU": 0.25,
+    "Memory": 512 
+  },
+  "PullStartedAt": "2023-07-21T15:45:33.532811081Z",
+  "PullStoppedAt": "2023-07-21T15:45:38.541068435Z",
+  "AvailabilityZone": "us-east-1a",
+}
+INSTANCE_DOCUMENT_ECS_FARGATE = json.dumps(INSTANCE_DATA_ECS_FARGATE)
+
+OPTIONS = {"crossaccount": None}
+DESCRIBE_AVAILABILITY_ZONES_RESPONSE = {
+    "AvailabilityZones": [
+        {
+            "State": "available",
+            "OptInStatus": "opt-in-not-required",
+            "Messages": [],
+            "RegionName": "us-east-1",
+            "ZoneName": "us-east-1a",
+            "ZoneId": "use1-az1",
+            "GroupName": "us-east-1",
+            "NetworkBorderGroup": "us-east-1"
+        },
+        {
+            "State": "available",
+            "OptInStatus": "opt-in-not-required",
+            "Messages": [],
+            "RegionName": "us-east-1",
+            "ZoneName": "us-east-1b",
+            "ZoneId": "use1-az2",
+            "GroupName": "us-east-1",
+            "NetworkBorderGroup": "us-east-1"
+        },
+        {
+            "State": "available",
+            "OptInStatus": "opt-in-not-required",
+            "Messages": [],
+            "RegionName": "us-east-1",
+            "ZoneName": "us-east-1c",
+            "ZoneId": "use1-az3",
+            "GroupName": "us-east-1",
+            "NetworkBorderGroup": "us-east-1"
+        },
+        {
+            "State": "available",
+            "OptInStatus": "opt-in-not-required",
+            "Messages": [],
+            "RegionName": "us-east-1",
+            "ZoneName": "us-east-1d",
+            "ZoneId": "use1-az4",
+            "GroupName": "us-east-1",
+            "NetworkBorderGroup": "us-east-1"
+        }
+    ]
+}
+
+@pytest.fixture(autouse=True)
+def setup(mocker):
+    mount_efs.INSTANCE_AZ_ID_METADATA = None
+
+
+class MockHeaders(object):
+    def __init__(self, content_charset=None):
+        self.content_charset = content_charset
+
+    def get_content_charset(self):
+        return self.content_charset
+
+
+class MockUrlLibResponse(object):
+    def __init__(self, code=200, data=INSTANCE_AZ_ID, headers=MockHeaders()):
+        self.code = code
+        self.data = data
+        self.headers = headers
+
+    def getcode(self):
+        return self.code
+
+    def read(self):
+        return self.data
+    
+class MockUrlLibResponseECSFargate(object):
+    def __init__(self, code=200, data=INSTANCE_DOCUMENT_ECS_FARGATE, headers=MockHeaders()):
+        self.code = code
+        self.data = data
+        self.headers = headers
+
+    def getcode(self):
+        return self.code
+
+    def read(self):
+        return self.data
+
+
+def _get_config(is_fargate=False):
+    try:
+        config = ConfigParser.SafeConfigParser()
+    except AttributeError:
+        config = ConfigParser()
+    config.add_section(mount_efs.CONFIG_SECTION)
+    if is_fargate:
+        config.add_section(mount_efs.CLIENT_INFO_SECTION)
+        config.set(mount_efs.CLIENT_INFO_SECTION, "source", "ecs.fargate")
+    config.set(
+        mount_efs.CONFIG_SECTION,
+        "dns_name_format",
+        "{az}.{fs_id}.efs.{region}.amazonaws.com",
+    )
+    return config
+
+
+
+def test_get_instance_az_id_helper():
+    return mount_efs.get_az_id_info_from_instance_metadata(
+        _get_config(), OPTIONS
+    )
+
+
+def test_get_instance_az_id_with_token(mocker):
+    mocker.patch("mount_efs.get_aws_ec2_metadata_token", return_value="ABCDEFG==")
+    mocker.patch("mount_efs.urlopen", return_value=MockUrlLibResponse())
+    assert INSTANCE_AZ_ID == test_get_instance_az_id_helper()
+
+
+def test_get_instance_az_id_without_token(mocker):
+    mocker.patch("mount_efs.get_aws_ec2_metadata_token", return_value=None)
+    mocker.patch("mount_efs.urlopen", return_value=MockUrlLibResponse())
+    assert INSTANCE_AZ_ID == test_get_instance_az_id_helper()
+
+
+# Reproduce https://github.com/aws/efs-utils/issues/46
+def test_get_instance_az_id_token_fetch_time_out(mocker):
+    # get_aws_ec2_metadata_token timeout, fallback to call without session token
+    mocker.patch(
+        "mount_efs.urlopen", side_effect=[socket.timeout, MockUrlLibResponse()]
+    )
+    assert INSTANCE_AZ_ID == test_get_instance_az_id_helper()
+
+
+def test_get_instance_az_id_py3_no_charset(mocker):
+    mocker.patch("mount_efs.get_aws_ec2_metadata_token", return_value=None)
+    mocker.patch(
+        "mount_efs.urlopen",
+        return_value=MockUrlLibResponse(data=bytearray(INSTANCE_AZ_ID, "us-ascii")),
+    )
+    assert INSTANCE_AZ_ID == test_get_instance_az_id_helper()
+
+
+def test_get_instance_az_id_py3_utf8_charset(mocker):
+    charset = "utf-8"
+    mocker.patch("mount_efs.get_aws_ec2_metadata_token", return_value=None)
+    mocker.patch(
+        "mount_efs.urlopen",
+        return_value=MockUrlLibResponse(data=bytearray(INSTANCE_AZ_ID, charset)),
+        headers=MockHeaders(content_charset=charset),
+    )
+    assert INSTANCE_AZ_ID == test_get_instance_az_id_helper()
+
+
+def test_get_instance_az_id_config_metadata_unavailable(mocker):
+    mocker.patch("mount_efs.get_aws_ec2_metadata_token", return_value=None)
+    mocker.patch("mount_efs.urlopen", side_effect=URLError("test error"))
+    instance_az_id = test_get_instance_az_id_helper()
+    assert instance_az_id == None
+
+
+def _test_get_instance_az_id_error(mocker, response=None, error=None):
+    mocker.patch("mount_efs.get_aws_ec2_metadata_token", return_value=None)
+    if (response and error) or (not response and not error):
+        raise ValueError("Invalid arguments")
+    elif response:
+        mocker.patch("mount_efs.urlopen", return_value=response)
+    elif error:
+        mocker.patch("mount_efs.urlopen", side_effect=error)
+
+    instance_az_id = test_get_instance_az_id_helper()
+    assert instance_az_id == None
+
+
+def test_get_instance_az_id_bad_response(mocker):
+    _test_get_instance_az_id_error(
+        mocker, error=HTTPError("url", 400, "Bad Request Error", None, None)
+    )
+
+
+def test_get_instance_az_id_error_response(mocker):
+    _test_get_instance_az_id_error(mocker, error=URLError("test error"))
+
+
+def test_get_instance_az_id_missing_instance_az_id(mocker):
+    _test_get_instance_az_id_error(
+        mocker,
+        response=MockUrlLibResponse(data=""),
+    )    
+
+
+def test_get_az_id_helper_ec2(mocker):
+    get_botocore_client_mock = mocker.patch(
+        "mount_efs.get_botocore_client", side_effect=[None, None]
+    )
+    assert INSTANCE_AZ_ID == mount_efs.get_az_id_helper(_get_config(), OPTIONS, INSTANCE_AZ_ID)
+    utils.assert_not_called(get_botocore_client_mock)
+
+
+def test_get_instance_az_id_ecs_fargate(mocker):
+    mocker.patch(
+        "os.getenv", return_value="http://169.254.170.2"
+    )
+    mocker.patch("mount_efs.urlopen", return_value=MockUrlLibResponseECSFargate())
+    mocker.patch(
+        "mount_efs.get_botocore_client", side_effect=[None, None]
+    )
+    mocker.patch(
+        "mount_efs.get_az_id_by_az_name_helper", return_value=DESCRIBE_AVAILABILITY_ZONES_RESPONSE
+    )
+    assert INSTANCE_AZ_ID == mount_efs.get_az_id_info_from_instance_metadata(
+        _get_config(is_fargate=True), OPTIONS
+    )
+
+
+def test_is_ecs_fargate_client_true(mocker):
+    assert mount_efs.is_ecs_fargate_client(_get_config(is_fargate=True)) == True
+
+
+def test_is_ecs_fargate_client_false(mocker):
+    assert mount_efs.is_ecs_fargate_client(_get_config(is_fargate=False)) == False
+
+
+def test_get_instance_az_id_metadata_url_ecs_fargate(mocker):
+    get_env_mock = mocker.patch(
+        "os.getenv", return_value="http://169.254.170.2"
+    )
+    assert mount_efs.get_instance_az_id_metadata_url(_get_config(is_fargate=True)) == FARGATE_AZ_ID_ENDPOINT
+    utils.assert_called_n_times(get_env_mock, 1)
+
+
+def test_get_instance_az_id_metadata_url_ec2(mocker):
+    assert mount_efs.get_instance_az_id_metadata_url(_get_config(is_fargate=False)) == mount_efs.INSTANCE_METADATA_SERVICE_AZ_ID_URL
+
+
+def test_get_instance_az_id_via_cached_instance_az_identity(mocker):
+    mocker.patch("mount_efs.get_aws_ec2_metadata_token", return_value="ABCDEFG==")
+    url_request_helper_mock_1 = mocker.patch(
+        "mount_efs.urlopen", return_value=MockUrlLibResponse()
+    )
+    assert mount_efs.INSTANCE_AZ_ID_METADATA == None
+    assert INSTANCE_AZ_ID == test_get_instance_az_id_helper()
+    utils.assert_called_n_times(url_request_helper_mock_1, 1)
+
+    # Verify the global INSTANCE_AZ_ID is cached with previous metadata api call result
+    assert mount_efs.INSTANCE_AZ_ID_METADATA == INSTANCE_AZ_ID
+    url_request_helper_mock_2 = mocker.patch("mount_efs.urlopen")
+    assert INSTANCE_AZ_ID == test_get_instance_az_id_helper()
+    # Verify there is no second api call when INSTANCE_AZ_ID is present
+    utils.assert_not_called(url_request_helper_mock_2)

--- a/test/mount_efs_test/test_main.py
+++ b/test/mount_efs_test/test_main.py
@@ -22,6 +22,7 @@ TLS_PORT = 10000
 AWSPROFILE = "test_profile"
 AWSCREDSURI = "/v2/credentials/{uuid}"
 TLSPORT_INCORRECT = "incorrect"
+AZ_ID = "usw1-az1"
 
 
 @contextmanager
@@ -42,6 +43,7 @@ def _test_main(
     tlsport=None,
     awscredsuri=None,
     notls=False,
+    crossaccount = False
 ):
     options = {}
 
@@ -65,6 +67,8 @@ def _test_main(
         options["tlsport"] = tlsport
     if awscredsuri is not None:
         options["awscredsuri"] = awscredsuri
+    if crossaccount:
+        options["crossaccount"] = None
 
     if root:
         mocker.patch("os.geteuid", return_value=0)
@@ -73,10 +77,16 @@ def _test_main(
 
     bootstrap_logging_mock = mocker.patch("mount_efs.bootstrap_logging")
     network_status_check_mock = mocker.patch("mount_efs.check_network_status")
-    get_dns_mock = mocker.patch(
-        "mount_efs.get_dns_name_and_fallback_mount_target_ip_address",
-        return_value=("fs-deadbeef.efs.us-west-1.amazonaws.com", None),
-    )
+    if crossaccount:
+        get_dns_mock = mocker.patch(
+            "mount_efs.get_dns_name_and_fallback_mount_target_ip_address",
+            return_value=("usw1-az1.fs-deadbeef.efs.us-west-1.amazonaws.com", None),
+        )
+    else:
+        get_dns_mock = mocker.patch(
+            "mount_efs.get_dns_name_and_fallback_mount_target_ip_address",
+            return_value=("fs-deadbeef.efs.us-west-1.amazonaws.com", None),
+        )
     parse_arguments_mock = mocker.patch(
         "mount_efs.parse_arguments", return_value=("fs-deadbeef", "/", "/mnt", options)
     )
@@ -320,3 +330,12 @@ def test_main_tls_ocsp_and_noocsp_option(mocker, capsys):
     _test_main_assert_error(
         mocker, capsys, expected_err, tls=True, tlsport=TLS_PORT, notls=True
     )
+
+def test_main_crossaccount_and_tls_option(mocker):
+    _test_main(mocker, crossaccount=True, tls=True, tlsport=TLS_PORT)
+    
+def test_main_crossaccount_without_tls_option(mocker):
+    _test_main(mocker, crossaccount=True, tls=False)
+
+def test_main_crossaccount_tls_and_ap_option(mocker):
+    _test_main(mocker, crossaccount=True, tls=True, ap_id=AP_ID, tlsport=TLS_PORT)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds the crossaccount mount option which can be used for cross-AWS-account mounts which require the client instance and EFS mount target to have the same availability zone ID/physical AZ location (e.g. use1-az1).

Tested via unit tests and manual testing:
```
[ec2-user@ip- ~]$ sudo mount -t efs -o crossaccount fs-redacted123:/ efs
[ec2-user@ip- ~]$ sudo umount efs
[ec2-user@ip- ~]$ sudo mount -t efs -o tls,crossaccount fs-redacted123:/ efs
[ec2-user@ip- ~]$ ls efs
hello.txt  out.txt
[ec2-user@ip- ~]$ sudo umount efs
[ec2-user@ip- ~]$ sudo mount -t efs -o tls,accesspoint=fsap-redacted123,crossaccount fs-redacted123:/ efs
[ec2-user@ip-192-168-0-254 ~]$ ls efs
hello.txt  out.txt
[ec2-user@ip- ~]$ sudo umount efs
[ec2-user@ip- ~]$ sudo mount -t efs -o tls,accesspoint=fsap-redacted123 fs-redacted123:/ efs
Failed to resolve "fs-redacted123.efs.ap-southeast-1.amazonaws.com" - check that your file system ID is correct, and ensure that the VPC has an EFS mount target for this file system ID.
See https://docs.aws.amazon.com/console/efs/mount-dns-name for more detail.
Attempting to lookup mount target ip address using botocore. Failed to import necessary dependency botocore, please install botocore first.
[ec2-user@ip- ~]$ sudo mount -t efs -o tls,accesspoint=fsap-redacted123,crossaccount fs-redacted123:/ efs
[ec2-user@ip- ~]$ ls efs
hello.txt  out.txt
[ec2-user@ip- ~]$ sudo umount efs

```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
