### PR TITLE
Release efs-utils v2.0.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,9 +38,19 @@ commands:
           command: |
             apt-get update
       - run:
+          name: Install curl
+          command: |
+            apt-get -y install curl
+      - run:
+          name: Install latest Rust
+          command: |
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+            . "$HOME/.cargo/env"
+      - run:
           name: Install dependencies
           command: |
-            apt-get -y install binutils git
+            DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
+            apt-get -y install binutils git rustc cargo pkg-config libssl-dev
       - run:
           name: Add local build repo as safe git directory
           command: |
@@ -49,6 +59,9 @@ commands:
       - run:
           name: Build DEB
           command: |
+            . "$HOME/.cargo/env"
+            rustc --version
+            cargo --version
             ./build-deb.sh
       - run:
           name: Install package
@@ -64,7 +77,7 @@ commands:
       - run:
           name: Install dependencies
           command: |
-            yum -y install rpm-build make systemd
+            yum -y install rpm-build make systemd rust cargo openssl-devel
       - run:
           name: Build RPM
           command: |
@@ -81,6 +94,40 @@ commands:
           name: Check changelog
           command: |
             rpm -q --changelog amazon-efs-utils
+  build-rpm-rustup:
+    steps:
+      - run:
+          name: Install dependencies
+          command: |
+            yum install -y curl
+      - run:
+          name: Install latest Rust
+          command: |
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      - checkout
+      - run:
+          name: Install dependencies
+          command: |
+            yum -y install rpm-build make systemd rust cargo openssl-devel
+      - run:
+          name: Build RPM
+          command: |
+            . "$HOME/.cargo/env"
+            rustc --version
+            make rpm
+      - run:
+          name: Install package
+          command: |
+            yum -y install build/amazon-efs-utils*rpm
+      - run:
+          name: Check installed successfully
+          command: |
+            mount.efs --version
+      - run:
+          name: Check changelog
+          command: |
+            rpm -q --changelog amazon-efs-utils
+
   build-suse-rpm:
     steps:
       - checkout
@@ -89,13 +136,23 @@ commands:
           command: |
             zypper refresh
       - run:
+          name: Install curl
+          command: |
+            zypper install -y curl
+      - run:
+          name: Install latest Rust
+          command: |
+            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      - run:
           name: Install dependencies
           command: |
             zypper install -y --force-resolution rpm-build
-            zypper install -y make systemd
+            zypper install -y make systemd rust cargo openssl-devel
       - run:
           name: Build RPM
           command: |
+            . "$HOME/.cargo/env"
+            rustc --version
             make rpm
       - run:
           name: Install package
@@ -116,14 +173,6 @@ commands:
         command: |
           sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
           sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
-  build-debian-eol-repo:
-    steps:
-      - run:
-          name: change repo url to archive.debian.org and remove updates repo for EOL versions
-          command: |
-            sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list
-            sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list
-            sed -i '/stretch-updates/d' /etc/apt/sources.list
 jobs:
   test:
     parameters:
@@ -152,6 +201,15 @@ jobs:
       image: << parameters.image >>
     steps:
       - build-rpm
+  build-rpm-package-rustup:
+    parameters:
+      image:
+        type: string
+    executor:
+      name: linux
+      image: << parameters.image >>
+    steps:
+      - build-rpm-rustup
   build-suse-rpm-package:
     parameters:
       image:
@@ -170,17 +228,7 @@ jobs:
       image: << parameters.image >>
     steps:
       - build-centos-repo
-      - build-rpm
-  build-debian-eol-rpm-package:
-    parameters:
-      image:
-        type: string
-    executor:
-      name: linux
-      image: << parameters.image >>
-    steps:
-      - build-debian-eol-repo
-      - build-deb
+      - build-rpm-rustup
 workflows:
   workflow:
     jobs:
@@ -217,21 +265,12 @@ workflows:
       - build-deb-package:
           name: ubuntu22
           image: ubuntu:22.04
-      - build-debian-eol-rpm-package:
-          name: debian9
-          image: debian:stretch
-      - build-deb-package:
-          name: debian10
-          image: debian:buster
       - build-deb-package:
           name: debian11
           image: debian:bullseye
       - build-centos-rpm-package:
           name: centos-latest
           image: centos:latest
-      - build-rpm-package:
-          name: centos7
-          image: centos:centos7
       - build-centos-rpm-package:
           name: centos8
           image: centos:centos8
@@ -245,30 +284,24 @@ workflows:
           name: amazon-linux-2
           image: amazonlinux:2
       - build-rpm-package:
-          name: amazon-linux
-          image: amazonlinux:1
-      - build-rpm-package:
           name: fedora-latest
           image: fedora:latest
-      - build-rpm-package:
-          name: fedora28
-          image: fedora:28
-      - build-rpm-package:
+      - build-rpm-package-rustup:
           name: fedora29
           image: fedora:29
-      - build-rpm-package:
+      - build-rpm-package-rustup:
           name: fedora30
           image: fedora:30
-      - build-rpm-package:
+      - build-rpm-package-rustup:
           name: fedora31
           image: fedora:31
-      - build-rpm-package:
+      - build-rpm-package-rustup:
           name: fedora32
           image: fedora:32
-      - build-rpm-package:
+      - build-rpm-package-rustup:
           name: fedora33
           image: fedora:33
-      - build-rpm-package:
+      - build-rpm-package-rustup:
           name: fedora34
           image: fedora:34
       - build-rpm-package:

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ PACKAGE_NAME = amazon-efs-utils
 SOURCE_TARBALL = $(PACKAGE_NAME).tar.gz
 SPECFILE = $(PACKAGE_NAME).spec
 BUILD_DIR = build/rpmbuild
+PROXY_VERSION = 2.0.0
 export PYTHONPATH := $(shell pwd)/src
 
 .PHONY: clean
@@ -31,6 +32,7 @@ tarball: clean
 	mkdir -p $(PACKAGE_NAME)/src
 	cp -rp src/mount_efs $(PACKAGE_NAME)/src
 	cp -rp src/watchdog $(PACKAGE_NAME)/src
+	cp -rp src/proxy $(PACKAGE_NAME)/src
 
 	mkdir -p ${PACKAGE_NAME}/man
 	cp -rp man/mount.efs.8 ${PACKAGE_NAME}/man
@@ -45,7 +47,8 @@ rpm-only:
 	mkdir -p $(BUILD_DIR)/{SPECS,COORD_SOURCES,DATA_SOURCES,BUILD,RPMS,SOURCES,SRPMS}
 	cp $(SPECFILE) $(BUILD_DIR)/SPECS
 	cp $(SOURCE_TARBALL) $(BUILD_DIR)/SOURCES
-	rpmbuild -ba --define "_topdir `pwd`/$(BUILD_DIR)" $(BUILD_DIR)/SPECS/$(SPECFILE)
+	cp config.toml $(BUILD_DIR)/SOURCES
+	rpmbuild -ba --define "_topdir `pwd`/$(BUILD_DIR)" --define "include_vendor_tarball false" $(BUILD_DIR)/SPECS/$(SPECFILE)
 	cp $(BUILD_DIR)/RPMS/*/*rpm build
 
 .PHONY: rpm

--- a/README.md
+++ b/README.md
@@ -8,21 +8,17 @@ The `efs-utils` package has been verified against the following Linux distributi
 
 | Distribution         | Package Type | `init` System |
 |----------------------| ----- | --------- |
-| Amazon Linux 2017.09 | `rpm` | `upstart` |
 | Amazon Linux 2       | `rpm` | `systemd` |
 | Amazon Linux 2023    | `rpm` | `systemd` |
-| CentOS 7             | `rpm` | `systemd` |
 | CentOS 8             | `rpm` | `systemd` |
 | RHEL 7               | `rpm` | `systemd` |
 | RHEL 8               | `rpm` | `systemd` |
 | RHEL 9               | `rpm` | `systemd` |
-| Fedora 28            | `rpm` | `systemd` |
 | Fedora 29            | `rpm` | `systemd` |
 | Fedora 30            | `rpm` | `systemd` |
 | Fedora 31            | `rpm` | `systemd` |
 | Fedora 32            | `rpm` | `systemd` |
-| Debian 9             | `deb` | `systemd` |
-| Debian 10            | `deb` | `systemd` |
+| Debian 11            | `deb` | `systemd` |
 | Ubuntu 16.04         | `deb` | `systemd` |
 | Ubuntu 18.04         | `deb` | `systemd` |
 | Ubuntu 20.04         | `deb` | `systemd` |
@@ -55,6 +51,7 @@ The `efs-utils` package has been verified against the following MacOS distributi
     - [MacOS](#macos)
     - [amazon-efs-mount-watchdog](#amazon-efs-mount-watchdog)
   - [Troubleshooting](#troubleshooting)
+  - [Upgrading to efs-utils v2.0.0](#upgrading-from-efs-utils-v1-to-v2)
   - [Upgrading stunnel for RHEL/CentOS](#upgrading-stunnel-for-rhelcentos)
   - [Upgrading stunnel for SLES12](#upgrading-stunnel-for-sles12)
   - [Upgrading stunnel for MacOS](#upgrading-stunnel-for-macos)
@@ -81,9 +78,11 @@ The `efs-utils` package has been verified against the following MacOS distributi
 ## Prerequisites
 
 * `nfs-utils` (RHEL/CentOS/Amazon Linux/Fedora) or `nfs-common` (Debian/Ubuntu)
-* OpenSSL 1.0.2+
+* OpenSSL-devel 1.0.2+
 * Python 3.4+
 * `stunnel` 4.56+
+- `rust` 1.68+
+- `cargo`
 
 ## Optional
 
@@ -93,7 +92,7 @@ The `efs-utils` package has been verified against the following MacOS distributi
 
 ### On Amazon Linux distributions
 
-For those using Amazon Linux or Amazon Linux 2, the easiest way to install `efs-utils` is from Amazon's repositories:
+For those using Amazon Linux, the easiest way to install `efs-utils` is from Amazon's repositories:
 
 ```bash
 $ sudo yum -y install amazon-efs-utils
@@ -121,7 +120,7 @@ Other distributions require building the package from source and installing it.
 If the distribution is not OpenSUSE or SLES
 
 ```bash
-$ sudo yum -y install git rpm-build make
+$ sudo yum -y install git rpm-build make rust cargo openssl-devel
 $ git clone https://github.com/aws/efs-utils
 $ cd efs-utils
 $ make rpm
@@ -132,7 +131,7 @@ Otherwise
 
 ```bash
 $ sudo zypper refresh
-$ sudo zypper install -y git rpm-build make
+$ sudo zypper install -y git rpm-build make rust cargo openssl-devel
 $ git clone https://github.com/aws/efs-utils
 $ cd efs-utils
 $ make rpm
@@ -152,11 +151,18 @@ sudo zypper refresh
 
 ```bash
 $ sudo apt-get update
-$ sudo apt-get -y install git binutils
+$ sudo apt-get -y install git binutils rustc cargo pkg-config libssl-dev
 $ git clone https://github.com/aws/efs-utils
 $ cd efs-utils
 $ ./build-deb.sh
 $ sudo apt-get -y install ./build/amazon-efs-utils*deb
+```
+
+If your Debian distribution doesn't provide a rust or cargo package, or your distribution provides versions
+that are older than 1.68, then you can install rust and cargo through rustup:
+```bash
+$ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+. "$HOME/.cargo/env"
 ```
 
 ### On MacOS Big Sur, macOS Monterey, macOS Sonoma and macOS Ventura distribution
@@ -194,8 +200,10 @@ $ make test
 ## Usage
 
 ### mount.efs
+`efs-utils` includes a mount helper utility, `mount.efs`, that simplifies and improves the performance of EFS file system mounts.
 
-`efs-utils` includes a mount helper utility to simplify mounting and using EFS file systems.
+`mount.efs` launches a proxy process that forwards NFS traffic from the kernel's NFS client to EFS.
+This proxy is responsible for TLS encryption, and for providing improved throughput performance.
 
 To mount with the recommended default options, simply run:
 
@@ -317,6 +325,16 @@ You can also enable stunnel debug logs with
 `sed -i '/stunnel_debug_enabled = false/s//stunnel_debug_enabled = true/g' /etc/amazon/efs/efs-utils.conf`.   
 
 Make sure to perform the failed mount again after running the prior commands before pulling the logs.
+
+## Upgrading from efs-utils v1 to v2
+Efs-utils v2.0.0 replaces stunnel, which provides TLS encryptions for mounts, with efs-proxy, a component built in-house at AWS.
+Efs-proxy lays the foundation for upcoming feature launches at EFS.
+
+To utilize the improved performance benefits of efs-proxy, you must re-mount any existing mounts. 
+
+Efs-proxy is not compatible with OCSP or Mac clients. In these cases, efs-utils will automatically revert back to using stunnel.  
+
+If you are building efs-utils v2.0.0 from source, then you need Rust and Cargo >= 1.68.
 
 ## Upgrading stunnel for RHEL/CentOS
 

--- a/build-deb.sh
+++ b/build-deb.sh
@@ -11,7 +11,7 @@ set -ex
 
 BASE_DIR=$(pwd)
 BUILD_ROOT=${BASE_DIR}/build/debbuild
-VERSION=1.36.0
+VERSION=2.0.0
 RELEASE=1
 DEB_SYSTEM_RELEASE_PATH=/etc/os-release
 
@@ -28,12 +28,18 @@ mkdir -p ${BUILD_ROOT}/usr/bin
 mkdir -p ${BUILD_ROOT}/var/log/amazon/efs
 mkdir -p ${BUILD_ROOT}/usr/share/man/man8
 
+echo 'Building efs-proxy'
+cd src/proxy
+cargo build --release --manifest-path ${BASE_DIR}/src/proxy/Cargo.toml
+cd ${BASE_DIR}
+
 echo 'Copying application files'
 install -p -m 644 dist/amazon-efs-mount-watchdog.conf ${BUILD_ROOT}/etc/init
 install -p -m 644 dist/amazon-efs-mount-watchdog.service ${BUILD_ROOT}/etc/systemd/system
 install -p -m 444 dist/efs-utils.crt ${BUILD_ROOT}/etc/amazon/efs
 install -p -m 644 dist/efs-utils.conf ${BUILD_ROOT}/etc/amazon/efs
 install -p -m 755 src/mount_efs/__init__.py ${BUILD_ROOT}/sbin/mount.efs
+install -p -m 755 src/proxy/target/release/efs-proxy ${BUILD_ROOT}/usr/bin/efs-proxy
 install -p -m 755 src/watchdog/__init__.py ${BUILD_ROOT}/usr/bin/amazon-efs-mount-watchdog
 
 echo 'Copying install scripts'

--- a/config.ini
+++ b/config.ini
@@ -7,5 +7,5 @@
 #
 
 [global]
-version=1.36.0
+version=2.0.0
 release=1

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,12 @@
+[source]
+	 
+# Under the `source` table are a number of other tables whose keys are a
+# name for the relevant source. For example this section defines a new
+# source, called `my-vendor-source`, which comes from a directory
+# located at `vendor` relative to the directory containing this `.cargo/config.toml`
+# file
+[source.my-vendor-source]
+directory = "vendor"
+
+[source.crates-io]
+replace-with = "my-vendor-source"

--- a/dist/amazon-efs-utils.control
+++ b/dist/amazon-efs-utils.control
@@ -1,6 +1,6 @@
 Package: amazon-efs-utils
 Architecture: all
-Version: 1.36.0
+Version: 2.0.0
 Section: utils
 Depends: python3, nfs-common, stunnel4 (>= 4.56), openssl (>= 1.0.2), util-linux
 Priority: optional

--- a/dist/efs-utils.crt
+++ b/dist/efs-utils.crt
@@ -1,12 +1,3 @@
-#
-# Copyright 2017-2018 Amazon.com, Inc. and its affiliates. All Rights Reserved.
-#
-# Licensed under the MIT License. See the LICENSE accompanying this file
-# for the specific language governing permissions and limitations under
-# the License.
-#
-
-# Amazon Root CA 1
 -----BEGIN CERTIFICATE-----
 MIIDQTCCAimgAwIBAgITBmyfz5m/jAo54vB4ikPmljZbyjANBgkqhkiG9w0BAQsF
 ADA5MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkwFwYDVQQDExBBbWF6
@@ -28,7 +19,6 @@ o/ufQJVtMVT8QtPHRh8jrdkPSHCa2XV4cdFyQzR1bldZwgJcJmApzyMZFo6IQ6XU
 rqXRfboQnoZsG4q5WTP468SQvvG5
 -----END CERTIFICATE-----
 
-# Amazon Root CA 2
 -----BEGIN CERTIFICATE-----
 MIIFQTCCAymgAwIBAgITBmyf0pY1hp8KD+WGePhbJruKNzANBgkqhkiG9w0BAQwF
 ADA5MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkwFwYDVQQDExBBbWF6
@@ -61,7 +51,6 @@ n749sSmvZ6ES8lgQGVMDMBu4Gon2nL2XA46jCfMdiyHxtN/kHNGfZQIG6lzWE7OE
 4PsJYGw=
 -----END CERTIFICATE-----
 
-# Amazon Root CA 3
 -----BEGIN CERTIFICATE-----
 MIIBtjCCAVugAwIBAgITBmyf1XSXNmY/Owua2eiedgPySjAKBggqhkjOPQQDAjA5
 MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkwFwYDVQQDExBBbWF6b24g
@@ -75,7 +64,6 @@ BqWTrBqYaGFy+uGh0PsceGCmQ5nFuMQCIQCcAu/xlJyzlvnrxir4tiz+OpAUFteM
 YyRIHN8wfdVoOw==
 -----END CERTIFICATE-----
 
-# Amazon Root CA 4
 -----BEGIN CERTIFICATE-----
 MIIB8jCCAXigAwIBAgITBmyf18G7EEwpQ+Vxe3ssyBrBDjAKBggqhkjOPQQDAzA5
 MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkwFwYDVQQDExBBbWF6b24g

--- a/man/mount.efs.8
+++ b/man/mount.efs.8
@@ -7,10 +7,13 @@
 .SH "DESCRIPTION"
 .sp
 \fBmount\&.efs\fR is part of the \fBamazon\-efs\-utils\fR \
-package, which simplifies using EFS file systems\&.
+package. It improves mount performance and simplifies using EFS file systems\&.
 .sp
 \fBmount\&.efs\fR is meant to be used through the \
 \fBmount\fR(8) command for mounting EFS file systems\&.
+.sp
+\fBmount\&.efs\fR launches a proxy process that forwards NFS traffic from the kernel's NFS client to EFS. \
+This proxy is responsible for TLS encryption, and for providing improved throughput performance.
 .sp
 \fIfs-id-or-dns-name\fR has to be of one of the following \
 two forms:
@@ -77,8 +80,9 @@ this option is by default passed and the EFS file system is mounted over TLS\&.
 Mounts the EFS file system without TLS, applies for Mac distributions only\&.
 .TP
 \fBtlsport=\fR\fIn\fR
-Configure the TLS relay to listen on the specified port\&. By default, the \
-tlsport is choosing randomly from port range defined in the config file located \
+Configures the proxy process to listen for connections from the NFS client on the specified port\&. This is applicable to both non-tls and tls mounts.
+ By default, the \
+tlsport is chosen randomly from port range defined in the config file located \
 at \fI/etc/amazon/efs/efs\-utils\&.conf\&\fR.
 .TP
 \fBverify=\fR\fIn\fR
@@ -88,7 +92,9 @@ more information, see \fBstunnel(8)\fR\&.
 \fBocsp / noocsp\fR
 Selects whether to perform OCSP validation on TLS certificates\&, \
 overriding /etc/amazon/efs/efs-utils.conf. By default OCSP is disabled. \
-For more information, see \fBstunnel(8)\fR\&.
+For more information, see \fBstunnel(8)\fR\&. \
+The ocsp mount option is incompatible with the efs-proxy process, and will revert efs-utils \
+to the legacy "stunnel" mode, which does not support improved per-client throughput performance.
 .TP
 \fBiam\fR
 Use the system's IAM identity to authenticate with EFS. The mount helper will try \
@@ -132,6 +138,12 @@ Use the port 2049 to bypass portmapper daemon on EC2 Mac instances running macOS
 .TP
 \fBmounttargetip\fR
 Mount the EFS file system to the specified mount target ip address\&.
+.TP
+\fBstunnel\fR
+Forward NFS traffic from the local NFS client to EFS using stunnel instead of efs-proxy.
+This will enable compatibility with the ocsp mount option, but will not
+deliver the increased throughput performance provided by efs-proxy. \
+This option is enabled by default for Mac clients.
 .if n \{\
 .RE
 .\}

--- a/src/proxy/Cargo.toml
+++ b/src/proxy/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "efs-proxy"
+edition = "2021"
+build = "build.rs"
+# The version of efs-proxy is tied to efs-utils.
+version = "2.0.0"
+publish = false
+
+[dependencies]
+anyhow = "1.0.72"
+async-trait = "0.1"
+bytes = { version = "1.4.0" }
+chrono = "0.4"
+clap = { version = "=4.0.0", features = ["derive"] }
+fern = "0.6"
+futures = "0.3"
+log = "0.4"
+log4rs = { version = "0", features = ["rolling_file_appender", "compound_policy", "size_trigger", "fixed_window_roller"]}
+nix = { version = "0.26.2", features = ["signal"]}
+onc-rpc = "0.2.3"
+rand = "0.8.5"
+s2n-tls = "0.0"
+s2n-tls-tokio = "0.0"
+s2n-tls-sys = "0.0"
+serde = {version="1.0.175",features=["derive"]}
+serde_ini = "0.2.0"
+thiserror = "1.0.44"
+tokio = { version = "1.29.0", features = ["full"] }
+tokio-util = "0.7.8"
+uuid = { version = "1.4.1", features = ["v4", "fast-rng", "macro-diagnostics"]}
+xdr-codec = "0.4.4"
+
+[dev-dependencies]
+test-case = "*"
+tokio = { version = "1.29.0", features = ["test-util"] }
+
+[build-dependencies]
+xdrgen = "0.4.4"

--- a/src/proxy/build.rs
+++ b/src/proxy/build.rs
@@ -1,0 +1,5 @@
+extern crate xdrgen;
+
+fn main() {
+    xdrgen::compile("src/efs_prot.x").expect("xdrgen efs_prot.x failed");
+}

--- a/src/proxy/src/config_parser.rs
+++ b/src/proxy/src/config_parser.rs
@@ -1,0 +1,211 @@
+use log::LevelFilter;
+use serde::{Deserialize, Serialize};
+use std::{error::Error, path::Path, str::FromStr};
+
+const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::Warn;
+
+fn default_log_level() -> String {
+    DEFAULT_LOG_LEVEL.to_string()
+}
+
+fn deserialize_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    match s.to_lowercase().as_str() {
+        "true" | "yes" | "1" => Ok(true),
+        "false" | "no" | "0" => Ok(false),
+        _ => Err(serde::de::Error::custom(format!("Invalid value: {}", s))),
+    }
+}
+
+#[derive(Default, Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub struct ProxyConfig {
+    #[serde(alias = "fips", deserialize_with = "deserialize_bool")]
+    pub fips: bool,
+
+    /// Logging level. Values should correspond to the log::LevelFilter enum.
+    #[serde(alias = "debug", default = "default_log_level")]
+    pub debug: String,
+
+    /// Output path for log files. Logging is disabled if this value is not provided.
+    #[serde(alias = "output")]
+    pub output: Option<String>,
+
+    /// The proxy process is responsible for writing it's PID into this file so that the Watchdog
+    /// process can monitor it
+    #[serde(alias = "pid")]
+    pub pid_file_path: String,
+
+    /// This nested structure is required for backwards compatibility
+    #[serde(alias = "efs")]
+    pub nested_config: EfsConfig,
+}
+
+impl FromStr for ProxyConfig {
+    type Err = serde_ini::de::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_ini::from_str(s)
+    }
+}
+
+impl ProxyConfig {
+    pub fn from_path(config_path: &Path) -> Result<Self, Box<dyn Error>> {
+        let config_string = std::fs::read_to_string(config_path)?;
+        let config = ProxyConfig::from_str(&config_string)?;
+        Ok(config)
+    }
+}
+
+#[derive(Default, Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub struct EfsConfig {
+    /// The mount target address - DNS name or IP address
+    #[serde(alias = "connect")]
+    pub mount_target_addr: String,
+
+    /// Listen for and accept connections on the specified host:port
+    #[serde(alias = "accept")]
+    pub listen_addr: String,
+
+    /// File path of the file that contains the client-side certificate and public key
+    #[serde(alias = "cert", default)]
+    pub client_cert_pem_file: String,
+
+    /// File path of the file that contains the client private key
+    #[serde(alias = "key", default)]
+    pub client_private_key_pem_file: String,
+
+    /// The hostname that is expected to be on the TLS certificate that the remote server presents
+    #[serde(alias = "checkHost", default)]
+    pub expected_server_hostname_tls: String,
+
+    /// File path of the certificate authority file.
+    /// This is used to verify the EFS server-side TLS certificate.
+    #[serde(alias = "CAfile", default)]
+    pub ca_file: String,
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use std::{path::Path, string::String};
+
+    pub static TEST_CONFIG_PATH: &str = "tests/certs/test_config.ini";
+
+    pub fn get_test_config() -> ProxyConfig {
+        ProxyConfig::from_path(&Path::new(TEST_CONFIG_PATH)).expect("Could not parse test config.")
+    }
+
+    #[test]
+    fn test_read_config_from_file() {
+        assert!(ProxyConfig::from_path(&Path::new(TEST_CONFIG_PATH)).is_ok());
+    }
+
+    #[test]
+    fn test_parse_config() {
+        let config_string = r#"fips = yes
+foreground = quiet
+socket = l:SO_REUSEADDR=yes
+socket = a:SO_BINDTODEVICE=lo
+debug = debug
+output = /var/log/amazon/efs/fs-12341234.home.ec2-user.efs.21036.efs-proxy.log
+pid = /var/run/efs/fs-12341234.home.ec2-user.efs.21036+/stunnel.pid
+port = 8081
+initial_partition_ip = 127.0.0.1:2049
+
+[efs]
+accept = 127.0.0.1:21036
+connect = fs-12341234.efs.us-east-1.amazonaws.com:2049
+sslVersion = TLSv1.2
+renegotiation = no
+TIMEOUTbusy = 20
+TIMEOUTclose = 0
+TIMEOUTidle = 70
+delay = yes
+verify = 2
+CAfile = /etc/amazon/efs/efs-utils.crt
+cert = /var/run/efs/fs-12341234.home.ec2-user.efs.21036+/certificate.pem
+key = /etc/amazon/efs/privateKey.pem
+checkHost = fs-12341234.efs.us-east-1.amazonaws.com
+"#;
+
+        let result_config = ProxyConfig::from_str(&config_string).unwrap();
+        let expected_proxy_config = ProxyConfig {
+            fips: true,
+            pid_file_path: String::from(
+                "/var/run/efs/fs-12341234.home.ec2-user.efs.21036+/stunnel.pid",
+            ),
+            debug: LevelFilter::Debug.to_string().to_ascii_lowercase(),
+            output: Some(String::from(
+                "/var/log/amazon/efs/fs-12341234.home.ec2-user.efs.21036.efs-proxy.log",
+            )),
+            nested_config: EfsConfig {
+                listen_addr: String::from("127.0.0.1:21036"),
+                mount_target_addr: String::from("fs-12341234.efs.us-east-1.amazonaws.com:2049"),
+                ca_file: String::from("/etc/amazon/efs/efs-utils.crt"),
+                client_cert_pem_file: String::from(
+                    "/var/run/efs/fs-12341234.home.ec2-user.efs.21036+/certificate.pem",
+                ),
+                client_private_key_pem_file: String::from("/etc/amazon/efs/privateKey.pem"),
+                expected_server_hostname_tls: String::from(
+                    "fs-12341234.efs.us-east-1.amazonaws.com",
+                ),
+            },
+        };
+
+        assert_eq!(result_config, expected_proxy_config);
+    }
+
+    #[test]
+    fn test_parse_config_fips_disabled() {
+        let config_string = r#"fips = no
+foreground = quiet
+socket = l:SO_REUSEADDR=yes
+socket = a:SO_BINDTODEVICE=lo
+pid = /var/run/efs/fs-12341234.home.ec2-user.efs.21036+/stunnel.pid
+port = 8081
+initial_partition_ip = 127.0.0.1:2049
+
+[efs]
+accept = 127.0.0.1:21036
+connect = fs-12341234.efs.us-east-1.amazonaws.com:2049
+sslVersion = TLSv1.2
+renegotiation = no
+TIMEOUTbusy = 20
+TIMEOUTclose = 0
+TIMEOUTidle = 70
+delay = yes
+verify = 2
+CAfile = /etc/amazon/efs/efs-utils.crt
+cert = /var/run/efs/fs-12341234.home.ec2-user.efs.21036+/certificate.pem
+key = /etc/amazon/efs/privateKey.pem
+checkHost = fs-12341234.efs.us-east-1.amazonaws.com
+"#;
+
+        let result_config = ProxyConfig::from_str(&config_string).unwrap();
+        let expected_proxy_config = ProxyConfig {
+            fips: false,
+            pid_file_path: String::from(
+                "/var/run/efs/fs-12341234.home.ec2-user.efs.21036+/stunnel.pid",
+            ),
+            debug: DEFAULT_LOG_LEVEL.to_string(),
+            output: None,
+            nested_config: EfsConfig {
+                listen_addr: String::from("127.0.0.1:21036"),
+                mount_target_addr: String::from("fs-12341234.efs.us-east-1.amazonaws.com:2049"),
+                ca_file: String::from("/etc/amazon/efs/efs-utils.crt"),
+                client_cert_pem_file: String::from(
+                    "/var/run/efs/fs-12341234.home.ec2-user.efs.21036+/certificate.pem",
+                ),
+                client_private_key_pem_file: String::from("/etc/amazon/efs/privateKey.pem"),
+                expected_server_hostname_tls: String::from(
+                    "fs-12341234.efs.us-east-1.amazonaws.com",
+                ),
+            },
+        };
+
+        assert_eq!(result_config, expected_proxy_config);
+    }
+}

--- a/src/proxy/src/connections.rs
+++ b/src/proxy/src/connections.rs
@@ -1,0 +1,710 @@
+use crate::efs_prot::{BindClientResponse, BindResponse, ScaleUpConfig};
+use crate::efs_rpc::{self, PartitionId};
+use crate::error::{ConnectError, RpcError};
+use crate::proxy_identifier::ProxyIdentifier;
+use crate::{
+    controller::Event, shutdown::ShutdownHandle, tls::establish_tls_stream, tls::TlsConfig,
+};
+use async_trait::async_trait;
+use futures::future;
+use log::{debug, info, warn};
+use s2n_tls_tokio::TlsStream;
+use std::sync::Arc;
+use std::{collections::HashMap, time::Duration};
+use tokio::task::JoinHandle;
+use tokio::time::timeout;
+use tokio::{
+    io::AsyncWriteExt,
+    io::{AsyncRead, AsyncWrite},
+    net::TcpStream,
+    sync::mpsc,
+};
+
+const CONCURRENT_ATTEMPT_COUNT: u32 = 3;
+
+pub const MAX_ATTEMPT_COUNT: u32 = 120;
+const SINGLE_CONNECTION_TIMEOUT_SEC: u64 = 15;
+pub const MULTIPLEX_CONNECTION_TIMEOUT_SEC: u64 = 15;
+
+pub trait ProxyStream: AsyncRead + AsyncWrite + Unpin + Send + 'static {}
+impl<T: AsyncRead + AsyncWrite + Unpin + Send + 'static> ProxyStream for T {}
+
+#[async_trait]
+pub trait PartitionFinder<S: ProxyStream> {
+    async fn establish_connection(
+        &self,
+        proxy_id: ProxyIdentifier,
+    ) -> Result<(S, Option<PartitionId>, Option<ScaleUpConfig>), ConnectError>;
+
+    async fn spawn_establish_connection_task(
+        &self,
+        proxy_id: ProxyIdentifier,
+    ) -> JoinHandle<Result<(S, Result<BindClientResponse, RpcError>), ConnectError>>;
+
+    // Establish multiple connections to an EFS "Partition" to enable higher IO throughput. A
+    // `target` partition should be provided if the proxy owns an existing connection to EFS. When
+    // provided, the search will prefer to find a connection that maps to this `target` partition.
+    // This `target` does not represent a hard requirement, as connections mapping to a different
+    // partition can still be returned.
+    //
+    async fn inner_establish_multiplex_connection(
+        &self,
+        proxy_id: ProxyIdentifier,
+        target: Option<PartitionId>,
+        shutdown_handle: ShutdownHandle,
+    ) -> Result<(PartitionId, Vec<S>, ScaleUpConfig), (ConnectError, Option<ScaleUpConfig>)> {
+        let mut connect_futures = Vec::with_capacity(CONCURRENT_ATTEMPT_COUNT as usize);
+        for _ in 0..CONCURRENT_ATTEMPT_COUNT {
+            connect_futures.push(self.spawn_establish_connection_task(proxy_id).await);
+        }
+
+        let mut connected_partitions: HashMap<PartitionId, Vec<S>> = HashMap::new();
+
+        let mut failure_count = 0;
+        let mut attempt_count = CONCURRENT_ATTEMPT_COUNT;
+
+        let overall_timeout =
+            tokio::time::sleep(Duration::from_secs(MULTIPLEX_CONNECTION_TIMEOUT_SEC));
+        tokio::pin!(overall_timeout);
+
+        loop {
+            tokio::select! {
+                (join_result, index, _) = future::select_all(connect_futures.iter_mut()) => {
+                    let Ok(connection_result) = join_result else {
+                        warn!("JoinError encountered during connection search.");
+                        tokio::spawn(shutdown_connections(connected_partitions));
+                        return Err((ConnectError::MultiplexFailure, None));
+                    };
+
+                    let (stream, bind_result) = match connection_result {
+                        Ok(r) => r,
+                        Err(ConnectError::IoError(e)) => {
+                            debug!("Retryable ConnectError encountered during connection search. Error: {:?}", e);
+                            failure_count += 1;
+                            self.retry_multiplex_connection_attempt(proxy_id, &mut attempt_count, index, &mut connect_futures).await?;
+                            continue;
+                        },
+                        Err(e) => {
+                            warn!("Non-retryable ConnectError encountered during connection search. Error: {}", e);
+                            tokio::spawn(shutdown_connections(connected_partitions));
+                            return Err((ConnectError::MultiplexFailure, None))
+                        }
+                    };
+
+                    let response = match bind_result {
+                        Ok(r) => r,
+                        Err(RpcError::IoError(e)) => {
+                            debug!("Retryable RpcError encountered during connection search. Error: {:?}", e);
+                            failure_count += 1;
+                            self.retry_multiplex_connection_attempt(proxy_id, &mut attempt_count, index, &mut connect_futures).await?;
+                            continue;
+                        },
+                        Err(e) => {
+                            warn!("Non-retryable RpcError encountered during connection search. Error: {}", e);
+                            tokio::spawn(shutdown_connections(connected_partitions));
+                            return Err((ConnectError::MultiplexFailure, None))
+                        }
+                    };
+
+                    let bind_response = response.bind_response;
+                    let new_scale_up_config = response.scale_up_config;
+                    debug!("Received {}", get_bind_response_string(&bind_response));
+                    match bind_response {
+                        BindResponse::READY(id) => {
+                            let partition_id = PartitionId { id: id.0 };
+
+                            if Some(partition_id) == target {
+                                debug!("Connection to target partition found. Attempt Count: {}, Failure Count: {}", attempt_count, failure_count);
+                            } else {
+                                debug!("Connection to non-target partition found. Attempt Count: {}, Failure Count: {}", attempt_count, failure_count);
+                            }
+
+                            if let Some(mut streams) = connected_partitions.remove(&partition_id) {
+                                streams.push(stream);
+
+                                let target_connection_count = if Some(partition_id) == target {
+                                    (new_scale_up_config.max_multiplexed_connections - 1) as usize
+                                } else {
+                                    new_scale_up_config.max_multiplexed_connections as usize
+                                };
+
+                                if streams.len() >= target_connection_count {
+                                    tokio::spawn(shutdown_connections(connected_partitions));
+                                    return Ok((partition_id, streams, new_scale_up_config));
+                                } else {
+                                    connected_partitions.insert(partition_id, streams);
+                                }
+                            } else {
+                                connected_partitions.insert(partition_id, vec!(stream));
+                            }
+                        },
+                        BindResponse::RETRY(_) | BindResponse::PREFERRED(_) => (),
+                        BindResponse::RETRY_LATER(_) | BindResponse::ERROR(_) | BindResponse::default => {
+                            tokio::spawn(shutdown_connections(connected_partitions));
+                            return Err((ConnectError::MultiplexFailure, Some(new_scale_up_config)))
+                        },
+                    };
+
+                    debug!("Continuing partition search. Attempt Count: {}, Failure Count: {}, Partitions Found: {}", attempt_count, failure_count, connected_partitions.len());
+                    self.retry_multiplex_connection_attempt(proxy_id, &mut attempt_count, index, &mut connect_futures).await?;
+                },
+                _ = &mut overall_timeout => {
+                    tokio::spawn(shutdown_connections(connected_partitions));
+                    return Err((ConnectError::Timeout, None));
+                },
+                _ = shutdown_handle.cancellation_token.cancelled() => {
+                    tokio::spawn(shutdown_connections(connected_partitions));
+                    return Err((ConnectError::Cancelled, None));
+                }
+            }
+        }
+    }
+
+    async fn retry_multiplex_connection_attempt(
+        &self,
+        proxy_id: ProxyIdentifier,
+        attempt_count: &mut u32,
+        last_failed_index: usize,
+        connect_futures: &mut Vec<
+            JoinHandle<Result<(S, Result<BindClientResponse, RpcError>), ConnectError>>,
+        >,
+    ) -> Result<(), (ConnectError, Option<ScaleUpConfig>)> {
+        if *attempt_count > MAX_ATTEMPT_COUNT {
+            return Err((ConnectError::MaxAttemptsExceeded, None));
+        } else {
+            connect_futures.swap_remove(last_failed_index);
+            connect_futures.push(self.spawn_establish_connection_task(proxy_id).await);
+            *attempt_count += 1;
+            Ok(())
+        }
+    }
+
+    // Increase the number of connections to the EFS Service.
+    async fn scale_up_connection(
+        &self,
+        proxy_id: ProxyIdentifier,
+        partition_id: Option<PartitionId>,
+        notification_queue: mpsc::Sender<Event<S>>,
+        shutdown_handle: ShutdownHandle,
+    ) {
+        let result = match self
+            .inner_establish_multiplex_connection(proxy_id, partition_id, shutdown_handle)
+            .await
+        {
+            Ok((id, proxy_streams, scale_up_config)) => {
+                notification_queue
+                    .send(Event::ConnectionSuccess(
+                        Some(id),
+                        proxy_streams,
+                        scale_up_config,
+                    ))
+                    .await
+            }
+            Err(e) => {
+                info!("Attempt to scale up failed: {}", e.0);
+                notification_queue.send(Event::ConnectionFail(e.1)).await
+            }
+        };
+        result.unwrap_or_else(|_| warn!("Unable to notify event queue of established connections"));
+    }
+}
+
+pub fn configure_stream(tcp_stream: TcpStream) -> TcpStream {
+    match tcp_stream.set_nodelay(true) {
+        Ok(_) => {}
+        Err(e) => warn!("Error setting TCP_NODELAY: {}", e),
+    }
+    tcp_stream
+}
+
+// Allow for graceful closure of Tls connections
+async fn shutdown_connections<S: ProxyStream>(connections: HashMap<PartitionId, Vec<S>>) {
+    for streams in connections.into_values() {
+        for mut stream in streams.into_iter() {
+            tokio::spawn(async move {
+                if let Err(e) = stream.shutdown().await {
+                    debug!("Failed to gracefully shutdown connection: {}", e);
+                }
+            });
+        }
+    }
+}
+
+// BindResponse in generated by xdrgen and does not implement the Debug or Display traits
+pub fn get_bind_response_string(bind_response: &BindResponse) -> String {
+    match bind_response {
+        BindResponse::PREFERRED(_partition_id) => String::from("BindResponse::PREFERRED"),
+        BindResponse::READY(_partition_id) => String::from("BindResponse::READY"),
+        BindResponse::RETRY(m) => {
+            if m.is_empty() {
+                String::from("BindResponse::RETRY")
+            } else {
+                format!("BindResponse::RETRY. message: {m}")
+            }
+        }
+        BindResponse::RETRY_LATER(m) => {
+            if m.is_empty() {
+                String::from("BindResponse::RETRY_LATER")
+            } else {
+                format!("BindResponse::RETRY_LATER. message: {m}")
+            }
+        }
+        BindResponse::ERROR(m) => {
+            if m.is_empty() {
+                String::from("BindResponse::ERROR")
+            } else {
+                format!("BindResponse::ERROR. message: {m}")
+            }
+        }
+        BindResponse::default => String::from("BindResponse::default"),
+    }
+}
+
+#[derive(Clone)]
+pub struct PlainTextPartitionFinder {
+    pub mount_target_addr: String,
+}
+
+impl PlainTextPartitionFinder {
+    async fn establish_plain_text_connection(
+        mount_target_addr: String,
+        proxy_id: ProxyIdentifier,
+    ) -> Result<(TcpStream, Result<BindClientResponse, RpcError>), ConnectError> {
+        timeout(Duration::from_secs(SINGLE_CONNECTION_TIMEOUT_SEC), async {
+            let mut tcp_stream = TcpStream::connect(mount_target_addr).await?;
+            let response = efs_rpc::bind_client_to_partition(proxy_id, &mut tcp_stream).await;
+            Ok((configure_stream(tcp_stream), response))
+        })
+        .await
+        .map_err(|_| ConnectError::Timeout)?
+    }
+}
+
+#[async_trait]
+impl PartitionFinder<TcpStream> for PlainTextPartitionFinder {
+    async fn establish_connection(
+        &self,
+        proxy_id: ProxyIdentifier,
+    ) -> Result<(TcpStream, Option<PartitionId>, Option<ScaleUpConfig>), ConnectError> {
+        let (s, bind_result) =
+            Self::establish_plain_text_connection(self.mount_target_addr.clone(), proxy_id).await?;
+        match bind_result {
+            Ok(response) => {
+                debug!(
+                    "EFS RPC call succeeded while establishing initial connection. Response: {}",
+                    get_bind_response_string(&response.bind_response)
+                );
+                let partition_id = match &response.bind_response {
+                    BindResponse::READY(id) => Some(PartitionId { id: id.0 }),
+                    _ => None,
+                };
+                Ok((s, partition_id, Some(response.scale_up_config)))
+            }
+            Err(e) => {
+                warn!("EFS RPC call errored while establishing initial connection. Error {e}",);
+                let tcp_stream = TcpStream::connect(self.mount_target_addr.clone()).await?;
+                return Ok((configure_stream(tcp_stream), None, None));
+            }
+        }
+    }
+
+    async fn spawn_establish_connection_task(
+        &self,
+        proxy_id: ProxyIdentifier,
+    ) -> JoinHandle<Result<(TcpStream, Result<BindClientResponse, RpcError>), ConnectError>> {
+        let addr = self.mount_target_addr.clone();
+        tokio::spawn(Self::establish_plain_text_connection(addr, proxy_id))
+    }
+}
+
+pub struct TlsPartitionFinder {
+    tls_config: Arc<tokio::sync::Mutex<TlsConfig>>,
+}
+
+impl TlsPartitionFinder {
+    pub fn new(tls_config: Arc<tokio::sync::Mutex<TlsConfig>>) -> Self {
+        TlsPartitionFinder { tls_config }
+    }
+
+    async fn establish_tls_connection(
+        tls_config: TlsConfig,
+        proxy_id: ProxyIdentifier,
+    ) -> Result<(TlsStream<TcpStream>, Result<BindClientResponse, RpcError>), ConnectError> {
+        timeout(Duration::from_secs(SINGLE_CONNECTION_TIMEOUT_SEC), async {
+            let mut tls_stream = establish_tls_stream(tls_config).await?;
+            let response = efs_rpc::bind_client_to_partition(proxy_id, &mut tls_stream).await;
+            Ok((tls_stream, response))
+        })
+        .await
+        .map_err(|_| ConnectError::Timeout)?
+    }
+}
+
+#[async_trait]
+impl PartitionFinder<TlsStream<TcpStream>> for TlsPartitionFinder {
+    async fn establish_connection(
+        &self,
+        proxy_id: ProxyIdentifier,
+    ) -> Result<
+        (
+            TlsStream<TcpStream>,
+            Option<PartitionId>,
+            Option<ScaleUpConfig>,
+        ),
+        ConnectError,
+    > {
+        let tls_config_copy = self.tls_config.lock().await.clone();
+        let (s, bind_result) = Self::establish_tls_connection(tls_config_copy, proxy_id).await?;
+        let (bind_response, scale_up_config) = match bind_result {
+            Ok(response) => {
+                warn!(
+                    "EFS RPC call succeeded while establishing initial connection. Response: {}",
+                    get_bind_response_string(&response.bind_response)
+                );
+                (response.bind_response, Some(response.scale_up_config))
+            }
+            Err(e) => {
+                warn!("EFS RPC call errored while establishing initial connection. Error {e}",);
+                let tls_stream = establish_tls_stream(self.tls_config.lock().await.clone()).await?;
+                return Ok((tls_stream, None, None));
+            }
+        };
+
+        match bind_response {
+            BindResponse::READY(id) => Ok((s, Some(PartitionId { id: id.0 }), scale_up_config)),
+            _ => Ok((s, None, scale_up_config)),
+        }
+    }
+
+    async fn spawn_establish_connection_task(
+        &self,
+        proxy_id: ProxyIdentifier,
+    ) -> JoinHandle<
+        Result<(TlsStream<TcpStream>, Result<BindClientResponse, RpcError>), ConnectError>,
+    > {
+        let tls_config_copy = self.tls_config.lock().await.clone();
+        tokio::spawn(Self::establish_tls_connection(tls_config_copy, proxy_id))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config_parser::tests::get_test_config;
+    use crate::connections::PartitionFinder;
+    use crate::controller::tests::{find_available_port, ServiceAction, TestService};
+    use crate::controller::DEFAULT_SCALE_UP_CONFIG;
+    use crate::ProxyConfig;
+    use nix::sys::signal::kill;
+    use nix::sys::signal::Signal;
+    use std::path::Path;
+    use std::str::FromStr;
+    use tokio::signal;
+    use tokio::sync::Mutex;
+    use tokio_util::sync::CancellationToken;
+    use uuid::Uuid;
+
+    const PROXY_ID: ProxyIdentifier = ProxyIdentifier {
+        uuid: Uuid::from_u128(1 as u128),
+        incarnation: 0,
+    };
+
+    struct MultiplexTest {
+        service: TestService,
+        partition_finder: TlsPartitionFinder,
+        initial_partition_id: PartitionId,
+    }
+
+    impl MultiplexTest {
+        async fn new() -> Self {
+            let service = TestService::new(true).await;
+            MultiplexTest::new_with_service(service).await
+        }
+
+        async fn new_with_service(service: TestService) -> Self {
+            let mut tls_config = TlsConfig::new_from_config(&get_test_config())
+                .await
+                .expect("Failed to acquire TlsConfig.");
+            tls_config.remote_addr = format!("127.0.0.1:{}", service.listen_port);
+
+            let partition_finder = TlsPartitionFinder::new(Arc::new(Mutex::new(tls_config)));
+
+            let (_s, id, _) = partition_finder
+                .establish_connection(PROXY_ID.clone())
+                .await
+                .expect("Failed to connect to server");
+
+            let Some(initial_partition_id) = id else {
+                panic!("Partition Id not found for initial connection.")
+            };
+
+            MultiplexTest {
+                service,
+                partition_finder: partition_finder,
+                initial_partition_id,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_establish_multiplex_same_partition_found() {
+        let test = MultiplexTest::new().await;
+
+        let (shutdown_handle, _waiter) = ShutdownHandle::new(CancellationToken::new());
+
+        let (new_connnection_id, connections, _) = test
+            .partition_finder
+            .inner_establish_multiplex_connection(
+                PROXY_ID.clone(),
+                Some(test.initial_partition_id.clone()),
+                shutdown_handle,
+            )
+            .await
+            .expect("Could not establish a multiplex connection");
+
+        assert_eq!(test.initial_partition_id, new_connnection_id);
+        assert_eq!(
+            DEFAULT_SCALE_UP_CONFIG.max_multiplexed_connections - 1,
+            connections.len() as i32
+        );
+
+        test.service.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_establish_multiplex_new_partition_found() {
+        let test = MultiplexTest::new().await;
+
+        let (shutdown_handle, _waiter) = ShutdownHandle::new(CancellationToken::new());
+
+        test.service
+            .post_action(ServiceAction::StopPartitionAcceptor(
+                test.initial_partition_id.clone(),
+            ))
+            .await;
+
+        let (new_connnection_id, connections, _) = test
+            .partition_finder
+            .inner_establish_multiplex_connection(
+                PROXY_ID.clone(),
+                Some(test.initial_partition_id.clone()),
+                shutdown_handle,
+            )
+            .await
+            .expect("Could not establish a multiplex connection");
+
+        assert_eq!(
+            DEFAULT_SCALE_UP_CONFIG.max_multiplexed_connections,
+            connections.len() as i32
+        );
+        assert_ne!(test.initial_partition_id, new_connnection_id);
+
+        test.service.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_establish_multiplex_no_target() {
+        let test = MultiplexTest::new().await;
+
+        let (shutdown_handle, _waiter) = ShutdownHandle::new(CancellationToken::new());
+
+        let (new_connnection_id, connections, _) = test
+            .partition_finder
+            .inner_establish_multiplex_connection(PROXY_ID.clone(), None, shutdown_handle)
+            .await
+            .expect("Could not establish a multiplex connection");
+
+        assert_eq!(
+            DEFAULT_SCALE_UP_CONFIG.max_multiplexed_connections,
+            connections.len() as i32
+        );
+        assert_ne!(test.initial_partition_id, new_connnection_id);
+
+        test.service.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_establish_connection_timeout() {
+        let (_listener, port) = find_available_port().await;
+
+        let error = tokio::spawn(async move {
+            let partition_finder = PlainTextPartitionFinder {
+                mount_target_addr: format!("127.0.0.1:{}", port.clone()),
+            };
+            partition_finder
+                .establish_connection(PROXY_ID.clone())
+                .await
+        })
+        .await
+        .expect("join err");
+
+        assert!(matches!(error, Err(ConnectError::Timeout)));
+    }
+
+    #[tokio::test]
+    async fn test_establish_multiplex_timeout() {
+        let (_listener, port) = find_available_port().await;
+
+        let error = tokio::spawn(async move {
+            let (shutdown_handle, _waiter) = ShutdownHandle::new(CancellationToken::new());
+
+            let partition_finder = PlainTextPartitionFinder {
+                mount_target_addr: format!("127.0.0.1:{}", port.clone()),
+            };
+            partition_finder
+                .inner_establish_multiplex_connection(PROXY_ID.clone(), None, shutdown_handle)
+                .await
+        })
+        .await
+        .expect("join err");
+
+        assert!(matches!(error, Err((ConnectError::Timeout, None))));
+    }
+
+    #[tokio::test]
+    async fn test_establish_multiplex_shutdown() {
+        let (_listener, port) = find_available_port().await;
+
+        let (shutdown_handle, _waiter) = ShutdownHandle::new(CancellationToken::new());
+
+        let shutdown_handle_clone = shutdown_handle.clone();
+        let task = tokio::spawn(async move {
+            let partition_finder = PlainTextPartitionFinder {
+                mount_target_addr: format!("127.0.0.1:{}", port.clone()),
+            };
+            partition_finder
+                .inner_establish_multiplex_connection(PROXY_ID.clone(), None, shutdown_handle_clone)
+                .await
+        });
+
+        shutdown_handle.exit(None).await;
+        let error = task.await.expect("Unexpected join error");
+
+        assert!(matches!(error, Err((ConnectError::Cancelled, None))));
+    }
+
+    #[tokio::test]
+    async fn test_scale_up_max_attempts() {
+        // Create a service in which the all calls of bind_client_to_partition will return a
+        // different value. Our "TestService" returns these PartitionIds in a round robin fashion,
+        // and this service will have more PartitionId than MAX_ATTEMPT_COUNT
+        let service =
+            TestService::new_with_partition_count((MAX_ATTEMPT_COUNT + 2) as usize, true).await;
+
+        let test = MultiplexTest::new_with_service(service).await;
+
+        let (shutdown_handle, _waiter) = ShutdownHandle::new(CancellationToken::new());
+
+        let error = test
+            .partition_finder
+            .inner_establish_multiplex_connection(
+                PROXY_ID.clone(),
+                Some(test.initial_partition_id.clone()),
+                shutdown_handle.clone(),
+            )
+            .await;
+
+        assert!(matches!(
+            error,
+            Err((ConnectError::MaxAttemptsExceeded, None))
+        ));
+    }
+
+    enum BrokenPartitionFinderType {
+        _ConnectIoError,
+        _RpcIoError,
+        RpcNonIoError,
+    }
+
+    struct BrokenPartitionFinder {
+        finder_type: BrokenPartitionFinderType,
+    }
+
+    impl BrokenPartitionFinder {
+        fn new(finder_type: BrokenPartitionFinderType) -> Self {
+            Self { finder_type }
+        }
+    }
+
+    #[async_trait]
+    impl PartitionFinder<TcpStream> for BrokenPartitionFinder {
+        async fn establish_connection(
+            &self,
+            _proxy_id: ProxyIdentifier,
+        ) -> Result<(TcpStream, Option<PartitionId>, Option<ScaleUpConfig>), ConnectError> {
+            unimplemented!()
+        }
+
+        async fn spawn_establish_connection_task(
+            &self,
+            _proxy_id: ProxyIdentifier,
+        ) -> JoinHandle<Result<(TcpStream, Result<BindClientResponse, RpcError>), ConnectError>>
+        {
+            let (_listener, port) = find_available_port().await;
+            let tcp_stream = TcpStream::connect(("127.0.0.1", port))
+                .await
+                .expect("Could not establish TCP stream.");
+            let error = match self.finder_type {
+                BrokenPartitionFinderType::_ConnectIoError => Err(ConnectError::IoError(
+                    tokio::io::ErrorKind::BrokenPipe.into(),
+                )),
+                BrokenPartitionFinderType::_RpcIoError => Ok((
+                    tcp_stream,
+                    Err(RpcError::IoError(tokio::io::ErrorKind::BrokenPipe.into())),
+                )),
+                BrokenPartitionFinderType::RpcNonIoError => {
+                    Ok((tcp_stream, Err(RpcError::GarbageArgs)))
+                }
+            };
+            tokio::spawn(async { error })
+        }
+    }
+
+    #[tokio::test]
+    async fn test_scale_up_rpc_error() {
+        let partition_finder = BrokenPartitionFinder::new(BrokenPartitionFinderType::RpcNonIoError);
+
+        let (shutdown_handle, _waiter) = ShutdownHandle::new(CancellationToken::new());
+        let error = partition_finder
+            .inner_establish_multiplex_connection(PROXY_ID.clone(), None, shutdown_handle.clone())
+            .await;
+
+        assert!(matches!(error, Err((ConnectError::MultiplexFailure, None))));
+    }
+
+    #[tokio::test]
+    async fn test_reload_certificate() {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let mut sigs_hangup_listener =
+            signal::unix::signal(signal::unix::SignalKind::hangup()).unwrap();
+        let config_file_path = Path::new("tests/certs/test_config.ini");
+        let config_contents = std::fs::read_to_string(&config_file_path).unwrap();
+        let proxy_config = ProxyConfig::from_str(&config_contents).unwrap();
+        let mut tls_config = TlsConfig::new_from_config(&proxy_config).await.unwrap();
+        tls_config.client_cert = vec![1, 2];
+        let old_cert = tls_config.client_cert.clone();
+        let tls_config_ptr = Arc::new(Mutex::new(tls_config));
+        let cloned_tls_config_ptr = Arc::clone(&tls_config_ptr);
+        tokio::spawn(async move {
+            loop {
+                // Check if the SIGHUP signal is received
+                if (sigs_hangup_listener.recv().await).is_some() {
+                    //Reloading the TLS configuration
+                    let mut locked_config = cloned_tls_config_ptr.lock().await;
+                    *locked_config = crate::get_tls_config(&proxy_config).await.unwrap();
+                    tx.send(()).unwrap();
+                    break;
+                }
+            }
+        });
+        let tls_partition_finder = TlsPartitionFinder {
+            tls_config: tls_config_ptr.clone(),
+        };
+        let _ = kill(nix::unistd::Pid::this(), Signal::SIGHUP);
+        rx.await.unwrap();
+        assert_ne!(
+            old_cert,
+            tls_partition_finder.tls_config.lock().await.client_cert
+        );
+    }
+}

--- a/src/proxy/src/controller.rs
+++ b/src/proxy/src/controller.rs
@@ -1,0 +1,1614 @@
+use crate::connections::configure_stream;
+use crate::efs_prot::ScaleUpConfig;
+use crate::efs_rpc::PartitionId;
+use crate::shutdown::ShutdownReason;
+use crate::status_reporter::{self, StatusReporter};
+use crate::{
+    connections::{PartitionFinder, ProxyStream},
+    proxy::{PerformanceStats, Proxy},
+    proxy_identifier::ProxyIdentifier,
+    shutdown::ShutdownHandle,
+};
+use log::{debug, error, info, warn};
+use std::{sync::Arc, time::Duration};
+use tokio::{net::TcpListener, sync::mpsc, time::Instant};
+use tokio_util::sync::CancellationToken;
+
+pub const DEFAULT_SCALE_UP_BACKOFF: Duration = Duration::from_secs(300);
+
+pub const DEFAULT_SCALE_UP_CONFIG: ScaleUpConfig = ScaleUpConfig {
+    max_multiplexed_connections: 5,
+    scale_up_bytes_per_sec_threshold: 300 * 1024 * 1024,
+    scale_up_threshold_breached_duration_sec: 1,
+};
+
+#[derive(Debug)]
+pub enum Event<S> {
+    ProxyUpdate(PerformanceStats),
+    ConnectionSuccess(Option<PartitionId>, Vec<S>, ScaleUpConfig),
+    ConnectionFail(Option<ScaleUpConfig>),
+}
+
+enum EventResult<S> {
+    Restart((Option<PartitionId>, Vec<S>, Option<ScaleUpConfig>)),
+    Ok,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum ConnectionSearchState {
+    SearchingAdditional(Option<PartitionId>),
+    Stop(Instant),
+    Idle,
+}
+
+struct IncarnationState<S: ProxyStream> {
+    pub proxy_id: ProxyIdentifier,
+    pub last_proxy_update: Option<(Instant, PerformanceStats)>,
+    pub partition_id: Option<PartitionId>,
+    connection_state: ConnectionSearchState,
+    pub num_connections: u16,
+    events_tx: mpsc::Sender<Event<S>>,
+}
+
+impl<S: ProxyStream> IncarnationState<S> {
+    fn new(
+        proxy_id: ProxyIdentifier,
+        partition_id: Option<PartitionId>,
+        events_tx: mpsc::Sender<Event<S>>,
+        num_connections: u16,
+    ) -> Self {
+        Self {
+            proxy_id,
+            last_proxy_update: None,
+            partition_id,
+            connection_state: ConnectionSearchState::Idle,
+            num_connections,
+            events_tx,
+        }
+    }
+}
+
+pub struct Controller<S: ProxyStream> {
+    listener: TcpListener,
+    partition_finder: Arc<dyn PartitionFinder<S> + Sync + Send>,
+    proxy_id: ProxyIdentifier,
+    scale_up_attempt_count: u64,
+    restart_count: u64,
+    scale_up_config: ScaleUpConfig,
+    status_reporter: StatusReporter,
+}
+
+impl<S: ProxyStream> Controller<S> {
+    pub async fn new(
+        listen_addr: &str,
+        partition_finder: Arc<impl PartitionFinder<S> + Sync + Send + 'static>,
+        status_reporter: StatusReporter,
+    ) -> Self {
+        let Ok(listener) = TcpListener::bind(listen_addr).await else {
+            panic!("Failed to bind {}", listen_addr);
+        };
+
+        Self {
+            listener,
+            partition_finder,
+            proxy_id: ProxyIdentifier::new(),
+            scale_up_attempt_count: 0,
+            restart_count: 0,
+            scale_up_config: DEFAULT_SCALE_UP_CONFIG,
+            status_reporter,
+        }
+    }
+
+    pub async fn run(mut self, token: CancellationToken) -> Option<ShutdownReason> {
+        let mut ready_connections = None;
+        loop {
+            info!("Starting new incarnation of proxy");
+            let nfs_client = match self.listener.accept().await {
+                Ok((client, socket_addr)) => {
+                    self.proxy_id.increment();
+                    info!(
+                        "Accepted new connection {:?}, {:?} ",
+                        socket_addr, self.proxy_id
+                    );
+                    configure_stream(client)
+                }
+                Err(e) => {
+                    error!("Failed to establish connection to NFS client. {e}");
+                    continue;
+                }
+            };
+
+            let peek_result = nfs_client.peek(&mut [0; 1]).await;
+            if let Ok(0) = peek_result {
+                // efs-utils performs a test in which it checks if a connection to the proxy port
+                // can be established. This connection is never used and is immediately closed.
+                // When this behavior is detected, this loops should be restarted so that another
+                // connection to the port can be established
+                debug!("Connection to nfs client was closed before any data was sent to the proxy. This is expected. Restarting controller");
+                continue;
+            } else if let Err(e) = peek_result {
+                error!("Failed to check if data was sent by the NFS client. {}", e);
+                return Some(ShutdownReason::UnexpectedError);
+            }
+
+            let (events_tx, mut events_rx) = mpsc::channel(1024);
+            let (shutdown, mut waiter) = ShutdownHandle::new(token.child_token());
+
+            let (partition_id, partition_servers, scale_up_config) = match ready_connections {
+                Some(connections) => {
+                    ready_connections = None;
+                    connections
+                }
+                None => {
+                    match self
+                        .partition_finder
+                        .establish_connection(self.proxy_id)
+                        .await
+                    {
+                        Ok((s, partition_id, scale_up_config)) => {
+                            (partition_id, vec![s], scale_up_config)
+                        }
+                        Err(e) => {
+                            warn!("Failed to establish an initial connection to EFS. Error: {e}",);
+                            continue;
+                        }
+                    }
+                }
+            };
+
+            match partition_id {
+                Some(id) => debug!("Established initial connection with PartitionId: {id:?}"),
+                None => debug!("Established initial connection without a PartitionId"),
+            }
+
+            self.scale_up_config = scale_up_config.unwrap_or(self.scale_up_config);
+            debug!("ScaleUpConfig: {:#?}", self.scale_up_config);
+
+            let mut state = IncarnationState::new(
+                self.proxy_id,
+                partition_id,
+                events_tx.clone(),
+                partition_servers.len() as u16,
+            );
+
+            let mut proxy = Proxy::new(nfs_client, partition_servers, events_tx, shutdown.clone());
+
+            loop {
+                let mut err = Ok(());
+                tokio::select! {
+                    _ = self.status_reporter.await_report_request() => {
+                        let report = status_reporter::Report {
+                            proxy_id: state.proxy_id,
+                            partition_id: state.partition_id,
+                            connection_state: state.connection_state.clone(),
+                            num_connections: state.num_connections as usize,
+                            last_proxy_update: state.last_proxy_update,
+                            scale_up_attempt_count: self.scale_up_attempt_count,
+                            restart_count: self.restart_count
+                        };
+                        self.status_reporter.publish_status(report).await;
+                    }
+                    event = events_rx.recv() => {
+                        if let Some(next_event) = event {
+                            match self.handle_event(next_event, &mut proxy, &mut state, shutdown.clone()).await {
+                                Ok(EventResult::Restart(connections)) => {
+                                    debug!("Restarting proxy to use multiple connections");
+                                    ready_connections = Some(connections);
+                                    shutdown.exit(Some(ShutdownReason::NeedsRestart)).await;
+                                    break;
+                                },
+                                Ok(EventResult::Ok) => continue,
+                                Err(e) => err = Err(e),
+                            };
+
+                        } else {
+                            err = Err("All senders have closed");
+                        }
+                    }
+                    _ = shutdown.cancellation_token.cancelled() => {
+                        debug!("Controller exiting due to child exit");
+                        break;
+                    }
+                    _ = self.listener.accept() => {
+                        warn!("Unexpected connection, ignoring")
+                    }
+                }
+                if err.is_err() {
+                    info!("Starting proxy restart due to {}", err.unwrap_err());
+                    break;
+                }
+            }
+
+            if let Some(count) = self.restart_count.checked_add(1) {
+                self.restart_count = count;
+            }
+
+            // Ensure that connection(s) to EFS is closed. If we can't successfully stop the proxy,
+            // then exit from this process and allow the watchdog to restart the efs-proxy program.
+            //
+            if let Err(e) = proxy.shutdown().await {
+                error!("Proxy shutdown failed. {}", e);
+                return Some(ShutdownReason::UnexpectedError);
+            };
+
+            let shutdown_reason = waiter.recv().await;
+            match shutdown_reason {
+                Some(ShutdownReason::NeedsRestart) => {
+                    debug!("Proxy restarting with ShutdownReason::NeedsRestart")
+                }
+                Some(ShutdownReason::Unmount) => {
+                    debug!("Proxy restarting with ShutdownReason::Unmount")
+                }
+                reason => return reason,
+            }
+        }
+    }
+
+    fn should_scale_up(&self, state: &mut IncarnationState<S>, stats: PerformanceStats) -> bool {
+        if let ConnectionSearchState::Stop(last_failure) = state.connection_state {
+            if Instant::now().duration_since(last_failure) > DEFAULT_SCALE_UP_BACKOFF {
+                state.connection_state = ConnectionSearchState::Idle;
+            }
+        }
+
+        state.num_connections == 1
+            && state.connection_state == ConnectionSearchState::Idle
+            && stats.get_total_throughput()
+                >= self.scale_up_config.scale_up_bytes_per_sec_threshold as u64
+    }
+
+    async fn handle_event(
+        &mut self,
+        event: Event<S>,
+        proxy: &mut Proxy<S>,
+        state: &mut IncarnationState<S>,
+        shutdown_handle: ShutdownHandle,
+    ) -> Result<EventResult<S>, &str> {
+        match event {
+            Event::ProxyUpdate(stats) => {
+                info!("Proxy performance: {:?}", stats);
+
+                if self.should_scale_up(state, stats) {
+                    info!("Searching for a new connection");
+                    if let Some(count) = self.scale_up_attempt_count.checked_add(1) {
+                        self.scale_up_attempt_count = count;
+                    }
+
+                    state.connection_state =
+                        ConnectionSearchState::SearchingAdditional(state.partition_id);
+                    self.partition_finder
+                        .scale_up_connection(
+                            state.proxy_id,
+                            state.partition_id,
+                            state.events_tx.clone(),
+                            shutdown_handle,
+                        )
+                        .await;
+                }
+            }
+            Event::ConnectionSuccess(id, streams, scale_up_config) => {
+                info!("Established new TCP connection to {:?}", id);
+                if state.partition_id == id {
+                    assert_eq!(
+                        (self.scale_up_config.max_multiplexed_connections - 1) as usize,
+                        streams.len()
+                    );
+                    for stream in streams {
+                        proxy.add_connection(stream).await;
+                    }
+                } else {
+                    assert_eq!(
+                        self.scale_up_config.max_multiplexed_connections as usize,
+                        streams.len()
+                    );
+                    assert!(id.is_some());
+                    assert_ne!(state.partition_id, id);
+
+                    return Ok(EventResult::Restart((id, streams, Some(scale_up_config))));
+                }
+                state.num_connections = self.scale_up_config.max_multiplexed_connections as u16;
+                state.connection_state = ConnectionSearchState::Idle;
+                self.scale_up_config = scale_up_config;
+            }
+            Event::ConnectionFail(scale_up_config) => {
+                state.connection_state = ConnectionSearchState::Stop(Instant::now());
+                self.scale_up_config = scale_up_config.unwrap_or(self.scale_up_config);
+                info!("Connection failed");
+            }
+        }
+        debug!("ScaleUpConfig: {:#?}", self.scale_up_config);
+        Ok(EventResult::Ok)
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use crate::config_parser::tests::get_test_config;
+    use crate::connections::PlainTextPartitionFinder;
+    use crate::connections::ProxyStream;
+    use crate::connections::MULTIPLEX_CONNECTION_TIMEOUT_SEC;
+    use crate::controller::ConnectionSearchState;
+    use crate::controller::DEFAULT_SCALE_UP_BACKOFF;
+    use crate::efs_prot;
+    use crate::efs_prot::BindResponse;
+    use crate::efs_prot::ScaleUpConfig;
+    use crate::efs_rpc;
+    use crate::efs_rpc::PartitionId;
+    use crate::proxy;
+    use crate::proxy_identifier::ProxyIdentifier;
+    use crate::proxy_identifier::INITIAL_INCARNATION;
+    use crate::rpc;
+    use crate::rpc::RPC_HEADER_SIZE;
+    use crate::shutdown::ShutdownReason;
+    use crate::status_reporter;
+    use crate::status_reporter::Report;
+    use crate::status_reporter::StatusRequester;
+    use crate::tls::tests::get_server_config;
+    use crate::tls::TlsConfig;
+    use crate::{connections::TlsPartitionFinder, controller::Controller};
+
+    use bytes::BytesMut;
+    use log::debug;
+    use onc_rpc::RpcMessage;
+    use rand::Rng;
+    use std::collections::HashMap;
+    use std::collections::HashSet;
+    use std::io::ErrorKind;
+    use std::sync::atomic::AtomicU32;
+    use std::time::Duration;
+    use std::{self, io::Error, sync::Arc};
+    use test_case::test_case;
+    use tokio::time::error::Elapsed;
+    use tokio::time::timeout;
+    use tokio::{
+        io::AsyncWriteExt,
+        net::{TcpListener, TcpStream},
+        sync::oneshot,
+        sync::Mutex,
+        task::JoinHandle,
+    };
+    use tokio_util::sync::CancellationToken;
+
+    use super::DEFAULT_SCALE_UP_CONFIG;
+
+    #[derive(Copy, Clone, Debug, PartialEq)]
+    pub enum ServiceAction {
+        // Server will reject the next incoming TCP connection. Further attempts will succeed.
+        //
+        RejectNextNewConnectionRequest,
+
+        // The server will close the next connection that receives a request from the proxy.
+        //
+        CloseOnNextRequest,
+
+        // The server will close a random connection without waiting for any incoming request.
+        //
+        CloseRandomConnection,
+
+        // This service will restart accepting connections to the given PartitionId
+        //
+        _RestartPartitionAcceptor(PartitionId),
+
+        // This service will not accept connections to the given PartitionId
+        //
+        StopPartitionAcceptor(PartitionId),
+
+        // This service will close the connection if a bind_client_to_partition request is received
+        //
+        CloseOnNextBindClientToPartitionRequest,
+
+        // The service will send BindResponse::RETRY_LATER on subsequent bind_client_to_partition requests
+        //
+        DisableScaleUp,
+
+        // The service will allow re-enabling scale up after the DisableScaleUp action is posted.
+        //
+        EnableScaleUp,
+
+        // The service will respond with BindResponse::RETRY on the next n bind_client_to_partition requests
+        SendRetries(u32),
+    }
+
+    const PARTITION_COUNT: usize = 3;
+
+    pub struct TestService {
+        pub listen_port: u16,
+        posted_action: Arc<Mutex<Option<ServiceAction>>>,
+        shutdown_tx: oneshot::Sender<()>,
+        join_handle: JoinHandle<()>,
+        pub partition_ids: Vec<PartitionId>,
+        pub stopped_partitions: Arc<Mutex<HashSet<PartitionId>>>,
+        pub request_counter: Arc<Mutex<HashMap<PartitionId, Vec<Arc<AtomicU32>>>>>,
+    }
+
+    impl TestService {
+        const ALWAYS_SCALE_UP_THRESHOLD_BYTES_PER_SEC: i32 = 0;
+        const NEVER_SCALE_UP_THRESHOLD_BYTES_PER_SEC: i32 = i32::MAX;
+
+        pub async fn new(tls: bool) -> Self {
+            TestService::new_with_partition_count(PARTITION_COUNT, tls).await
+        }
+
+        pub async fn new_with_partition_count(count: usize, tls: bool) -> Self {
+            TestService::new_with_partition_count_and_scale_up_config(
+                count,
+                super::DEFAULT_SCALE_UP_CONFIG,
+                tls,
+            )
+            .await
+        }
+
+        pub async fn new_with_throughput_scale_up_threshold(threshold: i32, tls: bool) -> Self {
+            let mut config = super::DEFAULT_SCALE_UP_CONFIG.clone();
+            config.scale_up_bytes_per_sec_threshold = threshold;
+            TestService::new_with_partition_count_and_scale_up_config(PARTITION_COUNT, config, tls)
+                .await
+        }
+
+        pub async fn new_with_partition_count_and_scale_up_threshold(
+            count: usize,
+            threshold: i32,
+            tls: bool,
+        ) -> Self {
+            let mut config = super::DEFAULT_SCALE_UP_CONFIG.clone();
+            config.scale_up_bytes_per_sec_threshold = threshold;
+            TestService::new_with_partition_count_and_scale_up_config(count, config, tls).await
+        }
+
+        pub async fn new_with_partition_count_and_scale_up_config(
+            count: usize,
+            scale_up_config: ScaleUpConfig,
+            tls: bool,
+        ) -> Self {
+            let (tcp_listener, listen_port) = find_available_port().await;
+
+            let partition_ids = (0..count)
+                .map(|_| PartitionId {
+                    id: efs_rpc::tests::generate_partition_id().0,
+                })
+                .collect::<Vec<PartitionId>>();
+
+            let stopped_partitions = Arc::new(Mutex::new(HashSet::new()));
+
+            let mut counter = HashMap::new();
+            for id in partition_ids.iter() {
+                counter.insert(id.clone(), Vec::new());
+            }
+            let request_counter = Arc::new(Mutex::new(counter));
+
+            let posted_action = Arc::new(Mutex::new(Option::None));
+            let (shutdown_tx, shutdown_rx) = oneshot::channel();
+
+            let service_handle = TestService::run(
+                tcp_listener,
+                scale_up_config,
+                partition_ids.clone(),
+                stopped_partitions.clone(),
+                request_counter.clone(),
+                posted_action.clone(),
+                tls,
+                shutdown_rx,
+            );
+
+            TestService {
+                listen_port,
+                posted_action,
+                shutdown_tx,
+                join_handle: service_handle,
+                partition_ids,
+                stopped_partitions,
+                request_counter,
+            }
+        }
+
+        pub async fn post_action(&self, new_action: ServiceAction) {
+            match new_action {
+                ServiceAction::_RestartPartitionAcceptor(id) => {
+                    let mut stopped = self.stopped_partitions.lock().await;
+                    assert!(stopped.remove(&id), "Partition is not stopped");
+                    return;
+                }
+                ServiceAction::StopPartitionAcceptor(id) => {
+                    let mut stopped = self.stopped_partitions.lock().await;
+                    stopped.insert(id);
+                    return;
+                }
+                ServiceAction::EnableScaleUp => {
+                    TestService::check_and_consume_action(
+                        &self.posted_action,
+                        ServiceAction::DisableScaleUp,
+                    )
+                    .await;
+                    return;
+                }
+                _ => (),
+            };
+
+            let mut consumable_action = self.posted_action.lock().await;
+            if consumable_action.is_some() {
+                panic!("Previous action was not consumed");
+            }
+            *consumable_action = Some(new_action);
+        }
+
+        fn run(
+            listener: TcpListener,
+            scale_up_config: ScaleUpConfig,
+            partition_ids: Vec<PartitionId>,
+            stopped_partitions: Arc<Mutex<HashSet<PartitionId>>>,
+            request_counter: Arc<Mutex<HashMap<PartitionId, Vec<Arc<AtomicU32>>>>>,
+            posted_action: Arc<Mutex<Option<ServiceAction>>>,
+            tls: bool,
+            mut shutdown_rx: oneshot::Receiver<()>,
+        ) -> JoinHandle<()> {
+            tokio::spawn(async move {
+                let mut partition_idx = 0;
+                loop {
+                    tokio::select! {
+                        socket = listener.accept() => {
+                            let Ok((tcp_stream, _socket_addr)) = socket else {
+                                panic!("Failed to establish connection to client");
+                            };
+
+                            if tls {
+                                let tls_acceptor = s2n_tls_tokio::TlsAcceptor::new(get_server_config().await.expect("Could not get config"));
+                                let tls_stream = match tls_acceptor.accept(tcp_stream).await {
+                                    Ok(conn) => conn,
+                                    Err(e) => {
+                                        panic!("Failed to establish TLS connection: {}", e);
+                                    }
+                                };
+                                Self::inner_run(tls_stream, scale_up_config, &mut partition_idx, &partition_ids, stopped_partitions.clone(), request_counter.clone(), posted_action.clone()).await;
+                            } else {
+                                Self::inner_run(tcp_stream, scale_up_config, &mut partition_idx, &partition_ids, stopped_partitions.clone(), request_counter.clone(), posted_action.clone()).await;
+                            }
+                        },
+                        _ = &mut shutdown_rx => {
+                            break;
+                        }
+                    };
+                }
+            })
+        }
+
+        async fn inner_run<S: ProxyStream>(
+            stream: S,
+            scale_up_config: ScaleUpConfig,
+            partition_idx: &mut usize,
+            partition_ids: &Vec<PartitionId>,
+            stopped_partitions: Arc<Mutex<HashSet<PartitionId>>>,
+            request_counter: Arc<Mutex<HashMap<PartitionId, Vec<Arc<AtomicU32>>>>>,
+            posted_action: Arc<Mutex<Option<ServiceAction>>>,
+        ) {
+            if TestService::check_and_consume_action(
+                &posted_action,
+                ServiceAction::RejectNextNewConnectionRequest,
+            )
+            .await
+                || TestService::check_and_consume_action(
+                    &posted_action,
+                    ServiceAction::CloseRandomConnection,
+                )
+                .await
+            {
+                debug!("RejectNextNewConnectionRequest processed");
+                drop(stream);
+            } else {
+                let stopped = stopped_partitions.lock().await;
+                let mut next_id = None;
+                for i in 0..partition_ids.len() {
+                    *partition_idx = (*partition_idx + i + 1) % partition_ids.len();
+                    if !stopped.contains(&partition_ids[*partition_idx]) {
+                        next_id = Some(partition_ids[*partition_idx].clone());
+                        break;
+                    }
+                }
+                let Some(id) = next_id else {
+                    panic!("No available PartitionIds")
+                };
+
+                let request_count = Arc::new(AtomicU32::new(0));
+                request_counter
+                    .lock()
+                    .await
+                    .get_mut(&id)
+                    .expect("Counter for partition not found")
+                    .push(request_count.clone());
+
+                tokio::spawn(TestService::new_connection(
+                    stream,
+                    scale_up_config,
+                    posted_action.clone(),
+                    id,
+                    request_count.clone(),
+                ));
+            }
+        }
+
+        async fn check_and_consume_action(
+            posted_action: &Arc<Mutex<Option<ServiceAction>>>,
+            to_check: ServiceAction,
+        ) -> bool {
+            let mut action = posted_action.lock().await;
+            if *action == Some(to_check) {
+                *action = Option::None;
+                true
+            } else {
+                false
+            }
+        }
+
+        async fn check_action(
+            posted_action: &Arc<Mutex<Option<ServiceAction>>>,
+            to_check: ServiceAction,
+        ) -> bool {
+            let action = posted_action.lock().await;
+            *action == Some(to_check)
+        }
+
+        async fn new_connection<S: ProxyStream>(
+            mut stream: S,
+            scale_up_config: ScaleUpConfig,
+            posted_action: Arc<Mutex<Option<ServiceAction>>>,
+            partition_id: PartitionId,
+            request_count: Arc<AtomicU32>,
+        ) {
+            loop {
+                let Ok(message) = rpc::read_rpc_bytes(&mut stream).await else {
+                    break;
+                };
+
+                request_count.fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+
+                if TestService::check_and_consume_action(
+                    &posted_action,
+                    ServiceAction::CloseOnNextRequest,
+                )
+                .await
+                {
+                    debug!("CloseOnNextRequest processed");
+                    break;
+                }
+
+                let response = match TestService::parse_bind_client_to_partition_request(&message) {
+                    Ok(rpc_message) => {
+                        if TestService::check_and_consume_action(
+                            &posted_action,
+                            ServiceAction::CloseOnNextBindClientToPartitionRequest,
+                        )
+                        .await
+                        {
+                            debug!("CloseOnNextBindClientToPartitionRequest processed");
+                            break;
+                        }
+
+                        let mut bind_response =
+                            BindResponse::READY(efs_prot::PartitionId(partition_id.id));
+
+                        if TestService::check_action(&posted_action, ServiceAction::DisableScaleUp)
+                            .await
+                        {
+                            bind_response = BindResponse::RETRY_LATER(
+                                "Returning BindResponse::RETRY_LATER".into(),
+                            );
+                        }
+
+                        let mut action = posted_action.lock().await;
+                        if let Some(ServiceAction::SendRetries(count)) = *action {
+                            bind_response =
+                                BindResponse::RETRY("Returning BindResponse::RETRY".into());
+                            if count > 1 {
+                                *action = Some(ServiceAction::SendRetries(count - 1));
+                            } else {
+                                *action = None;
+                            }
+                        }
+
+                        efs_rpc::tests::create_bind_client_to_partition_response(
+                            rpc_message.xid(),
+                            bind_response,
+                            scale_up_config,
+                        )
+                        .expect("Could not create response")
+                    }
+                    Err(_) => {
+                        // If the test server doesn't parse a `bind_client_to_partition` request,
+                        // then echo request back to the client
+                        message
+                    }
+                };
+
+                stream
+                    .write_all(&response)
+                    .await
+                    .expect("Could not write to stream");
+            }
+        }
+
+        fn parse_bind_client_to_partition_request(
+            request: &Vec<u8>,
+        ) -> Result<RpcMessage<&[u8], &[u8]>, Box<dyn std::error::Error + Send + Sync>> {
+            let rpc_message = onc_rpc::RpcMessage::try_from(request.as_slice())?;
+            efs_rpc::tests::parse_bind_client_to_partition_request(&rpc_message)?;
+            Ok(rpc_message)
+        }
+
+        pub async fn shutdown(self) {
+            drop(self.shutdown_tx);
+            self.join_handle.await.unwrap();
+        }
+    }
+
+    struct TestClient {
+        stream: TcpStream,
+        next_xid: u32,
+    }
+
+    impl TestClient {
+        async fn new(proxy_port: u16) -> Self {
+            let stream = TcpStream::connect(("127.0.0.1", proxy_port)).await.unwrap();
+            Self {
+                stream,
+                next_xid: 0,
+            }
+        }
+
+        async fn send_message_with_size(&mut self, size: usize) -> Result<(), Error> {
+            self.next_xid += 1;
+            let (request, expected_data) = rpc::test::generate_msg_fragments(size, 1);
+            self.stream.write_all(&request).await?;
+
+            let response = rpc::read_rpc_bytes(&mut self.stream).await?;
+
+            let payload_result =
+                rpc::RpcBatch::parse_batch(&mut BytesMut::from(response.as_slice()))
+                    .expect("No message found")
+                    .expect("failed to parse");
+
+            let rpc = payload_result.rpcs.get(0).expect("No RPCs found");
+            assert_eq!(expected_data, rpc.to_vec()[RPC_HEADER_SIZE..]);
+            Ok(())
+        }
+
+        async fn send_partial_message_with_size(&mut self, size: usize) -> Result<(), Error> {
+            self.next_xid += 1;
+            let (_, m1) = rpc::test::generate_msg_fragments(size, 1);
+            let mut rng = rand::thread_rng();
+            self.stream
+                .write_all(&m1[0..rng.gen_range(1..size - 1)])
+                .await?;
+            Ok(())
+        }
+    }
+
+    pub struct ProxyUnderTest {
+        listen_port: u16,
+        handle: JoinHandle<Option<ShutdownReason>>,
+        status_requester: StatusRequester,
+        scale_up_config: ScaleUpConfig,
+    }
+
+    impl ProxyUnderTest {
+        pub async fn new(tls: bool, server_port: u16) -> Self {
+            let scale_up_config = DEFAULT_SCALE_UP_CONFIG;
+            let (tcp_listener, listen_port) = find_available_port().await;
+
+            let (status_requester, status_reporter) = status_reporter::create_status_channel();
+
+            let handle = if tls {
+                let mut tls_config = TlsConfig::new_from_config(&get_test_config())
+                    .await
+                    .expect("Failed to acquire TlsConfig.");
+                tls_config.remote_addr = format!("127.0.0.1:{}", server_port);
+
+                let partition_finder =
+                    Arc::new(TlsPartitionFinder::new(Arc::new(Mutex::new(tls_config))));
+
+                let controller = Controller {
+                    listener: tcp_listener,
+                    partition_finder,
+                    proxy_id: ProxyIdentifier::new(),
+                    scale_up_attempt_count: 0,
+                    restart_count: 0,
+                    scale_up_config: scale_up_config,
+                    status_reporter,
+                };
+
+                let token = CancellationToken::new();
+                tokio::spawn(controller.run(token))
+            } else {
+                let partition_finder = Arc::new(PlainTextPartitionFinder {
+                    mount_target_addr: format!("127.0.0.1:{}", server_port),
+                });
+
+                let controller = Controller {
+                    listener: tcp_listener,
+                    partition_finder,
+                    proxy_id: ProxyIdentifier::new(),
+                    scale_up_attempt_count: 0,
+                    restart_count: 0,
+                    scale_up_config: scale_up_config,
+                    status_reporter,
+                };
+
+                let token = CancellationToken::new();
+                tokio::spawn(controller.run(token))
+            };
+
+            Self {
+                listen_port,
+                handle,
+                status_requester,
+                scale_up_config,
+            }
+        }
+
+        pub async fn poll_scale_up(&mut self) -> Result<(), Elapsed> {
+            timeout(Duration::from_secs(5), async {
+                loop {
+                    let num_connections = self.get_num_connections().await;
+                    if num_connections == self.scale_up_config.max_multiplexed_connections as usize
+                    {
+                        break;
+                    } else {
+                        tokio::time::sleep(Duration::from_millis(500)).await;
+                    }
+                }
+            })
+            .await
+        }
+
+        pub async fn get_report(&mut self) -> Report {
+            self.status_requester
+                ._request_status()
+                .await
+                .expect("Could not get report")
+        }
+
+        pub async fn get_proxy_id(&mut self) -> ProxyIdentifier {
+            let report = self.get_report().await;
+            report.proxy_id
+        }
+
+        async fn get_num_connections(&mut self) -> usize {
+            let report = self.get_report().await;
+            report.num_connections
+        }
+    }
+
+    pub async fn find_available_port() -> (TcpListener, u16) {
+        for port in 10000..15000 {
+            match TcpListener::bind(("127.0.0.1", port)).await {
+                Ok(v) => {
+                    return (v, port);
+                }
+                Err(_) => continue,
+            }
+        }
+        panic!("Failed to find port");
+    }
+
+    #[test_case(true; "tls enabled")]
+    #[test_case(false; "tls disabled")]
+    #[tokio::test]
+    async fn test_basic(tls_enabled: bool) {
+        let service = TestService::new(tls_enabled).await;
+        let mut proxy = ProxyUnderTest::new(tls_enabled, service.listen_port).await;
+        let mut client = TestClient::new(proxy.listen_port).await;
+        client.send_message_with_size(10).await.unwrap();
+        client.send_message_with_size(1024).await.unwrap();
+
+        let report = proxy.get_report().await;
+        assert!(report.partition_id.is_some());
+
+        service.shutdown().await;
+    }
+
+    #[test_case(true; "tls enabled")]
+    #[test_case(false; "tls disabled")]
+    #[tokio::test]
+    async fn test_success_after_connection_closed_on_bind_client_to_partition_request(
+        tls_enabled: bool,
+    ) {
+        let service = TestService::new(tls_enabled).await;
+        let mut proxy = ProxyUnderTest::new(tls_enabled, service.listen_port).await;
+        let mut client = TestClient::new(proxy.listen_port).await;
+
+        service
+            .post_action(ServiceAction::CloseOnNextBindClientToPartitionRequest)
+            .await;
+
+        client.send_message_with_size(10).await.unwrap();
+        client.send_message_with_size(1024).await.unwrap();
+
+        let report = proxy.get_report().await;
+        assert!(report.partition_id.is_none());
+
+        service.shutdown().await;
+    }
+
+    #[test_case(true; "tls enabled")]
+    #[test_case(false; "tls disabled")]
+    #[tokio::test]
+    async fn test_success_after_bind_client_to_partition_stop_response_on_initial_connection(
+        tls_enabled: bool,
+    ) {
+        let service = TestService::new(tls_enabled).await;
+        let mut proxy = ProxyUnderTest::new(tls_enabled, service.listen_port).await;
+        let mut client = TestClient::new(proxy.listen_port).await;
+
+        service.post_action(ServiceAction::DisableScaleUp).await;
+
+        client.send_message_with_size(10).await.unwrap();
+        client.send_message_with_size(1024).await.unwrap();
+
+        let report = proxy.get_report().await;
+        assert!(report.partition_id.is_none());
+
+        service.shutdown().await;
+    }
+
+    #[test_case(true; "tls enabled")]
+    #[test_case(false; "tls disabled")]
+    #[tokio::test]
+    async fn test_closed_connection(tls_enabled: bool) {
+        let service = TestService::new(tls_enabled).await;
+        let proxy = ProxyUnderTest::new(tls_enabled, service.listen_port).await;
+        let mut client = TestClient::new(proxy.listen_port).await;
+        client.send_message_with_size(10).await.unwrap();
+        service.post_action(ServiceAction::CloseOnNextRequest).await;
+        let result = client.send_message_with_size(10).await;
+        assert!(result.is_err());
+    }
+
+    #[test_case(true; "tls enabled")]
+    #[test_case(false; "tls disabled")]
+    #[tokio::test]
+    async fn test_closed_connection_after_scale_up(tls_enabled: bool) {
+        // Use a single partition so that the same PartitionId is return on each
+        // bind_client_to_partition request. This prevents a controller "reset", which simplifies
+        // testing that the proxy will retry scale up after the backoff time as elapsed.
+        //
+        let scale_up_threshold = 10;
+        let service = TestService::new_with_partition_count_and_scale_up_threshold(
+            1,
+            scale_up_threshold,
+            tls_enabled,
+        )
+        .await;
+
+        let mut proxy = ProxyUnderTest::new(tls_enabled, service.listen_port).await;
+
+        let mut client = TestClient::new(proxy.listen_port).await;
+        client.send_message_with_size(100).await.unwrap();
+
+        // Expect that scale up does not occur
+        proxy.poll_scale_up().await.expect("Scale up did not occur");
+
+        // Close one proxy connection. The subsequent requests should fail.
+        service.post_action(ServiceAction::CloseOnNextRequest).await;
+        client.send_message_with_size(100).await.unwrap_err();
+
+        // Wait some time for proxy to reset
+        tokio::time::sleep(Duration::from_secs(5)).await;
+
+        for _ in 0..5 {
+            client.send_message_with_size(100).await.unwrap_err();
+        }
+
+        // Reconnecting with the client should result in successful requests
+        let mut new_client = TestClient::new(proxy.listen_port).await;
+        new_client.send_message_with_size(5).await.unwrap();
+
+        let num_connections = proxy.get_report().await.num_connections;
+        assert_eq!(1, num_connections);
+
+        service.shutdown().await;
+    }
+
+    #[test_case(true; "tls enabled")]
+    #[test_case(false; "tls disabled")]
+    #[tokio::test]
+    async fn test_closed_connection_when_big_frame_sent(tls_enabled: bool) {
+        let service = TestService::new(tls_enabled).await;
+        let proxy = ProxyUnderTest::new(tls_enabled, service.listen_port).await;
+        let mut client = TestClient::new(proxy.listen_port).await;
+        let result = client.send_message_with_size(22222220).await;
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert!(
+            error.kind() == ErrorKind::BrokenPipe || error.kind() == ErrorKind::ConnectionReset
+        );
+        let reason_opt = proxy.handle.await.unwrap();
+        assert_eq!(reason_opt, Some(ShutdownReason::FrameSizeExceeded));
+    }
+
+    #[test_case(true; "tls enabled")]
+    #[test_case(false; "tls disabled")]
+    #[tokio::test]
+    async fn test_message_too_small(tls_enabled: bool) {
+        let service = TestService::new(tls_enabled).await;
+        let proxy = ProxyUnderTest::new(tls_enabled, service.listen_port).await;
+        let mut client = TestClient::new(proxy.listen_port).await;
+        let _ = client.send_message_with_size(1).await;
+        let reason_opt = proxy.handle.await.unwrap();
+        assert_eq!(reason_opt, Some(ShutdownReason::FrameSizeTooSmall));
+    }
+
+    #[test_case(true; "tls enabled")]
+    #[test_case(false; "tls disabled")]
+    #[tokio::test]
+    async fn test_client_disconnects(tls_enabled: bool) {
+        let service = TestService::new(tls_enabled).await;
+        let proxy = ProxyUnderTest::new(tls_enabled, service.listen_port).await;
+        let mut initial_client = TestClient::new(proxy.listen_port).await;
+        let _ = initial_client.send_partial_message_with_size(1000).await;
+        // Drop has been implemented to simulate client disconnection
+        drop(initial_client);
+
+        // After initial_client is disconnects, the proxy should still accept new connection
+        let mut client = TestClient::new(proxy.listen_port).await;
+        assert!(matches!(
+            client.send_partial_message_with_size(1000).await,
+            Ok(())
+        ));
+    }
+
+    #[test_case(true; "tls enabled")]
+    #[test_case(false; "tls disabled")]
+    #[tokio::test]
+    async fn test_client_disconnects_without_send(tls_enabled: bool) {
+        let service = TestService::new(tls_enabled).await;
+        let proxy = ProxyUnderTest::new(tls_enabled, service.listen_port).await;
+
+        // Drop this client to simulate a connection to the proxy port that immediately closes
+        let disconnecting_client = TestClient::new(proxy.listen_port).await;
+        drop(disconnecting_client);
+
+        // After the connection to the disconnecting_client is dropped, the proxy should still accept new connection
+        let mut client = TestClient::new(proxy.listen_port).await;
+        assert!(matches!(
+            client.send_partial_message_with_size(1000).await,
+            Ok(())
+        ));
+    }
+
+    #[test_case(true; "tls enabled")]
+    #[test_case(false; "tls disabled")]
+    #[tokio::test]
+    async fn test_handle_server_disconnect(tls_enabled: bool) {
+        let service = TestService::new(tls_enabled).await;
+        let mut proxy = ProxyUnderTest::new(tls_enabled, service.listen_port).await;
+
+        let mut client = TestClient::new(proxy.listen_port).await;
+        assert!(client.send_message_with_size(10).await.is_ok());
+
+        // Incarnation is incremented when connection with NFS client is established
+        assert_eq!(
+            INITIAL_INCARNATION + 1,
+            proxy.get_proxy_id().await.incarnation
+        );
+
+        service.post_action(ServiceAction::CloseOnNextRequest).await;
+
+        assert!(client.send_message_with_size(10).await.is_err());
+
+        // Reconnect
+        client = TestClient::new(proxy.listen_port).await;
+        assert!(client.send_message_with_size(10).await.is_ok());
+
+        // Incarnation is incremented when connection with NFS client is reestablished
+        assert_eq!(
+            INITIAL_INCARNATION + 2,
+            proxy.get_proxy_id().await.incarnation
+        );
+
+        proxy.handle.abort();
+        service.shutdown().await;
+    }
+
+    #[test_case(true; "tls enabled")]
+    #[test_case(false; "tls disabled")]
+    #[tokio::test]
+    async fn test_scale_up_same_partition(tls_enabled: bool) {
+        let service = TestService::new_with_partition_count_and_scale_up_threshold(
+            1,
+            TestService::ALWAYS_SCALE_UP_THRESHOLD_BYTES_PER_SEC,
+            tls_enabled,
+        )
+        .await;
+        let mut proxy = ProxyUnderTest::new(tls_enabled, service.listen_port).await;
+
+        // A request from the client will cause the proxy to establish an addition connection to the NFS server
+        let mut client = TestClient::new(proxy.listen_port).await;
+        client.send_message_with_size(10).await.unwrap();
+
+        proxy
+            .poll_scale_up()
+            .await
+            .expect("Timeout exceeded while awaiting scale up");
+
+        service.shutdown().await;
+    }
+
+    #[test_case(true; "tls enabled")]
+    #[test_case(false; "tls disabled")]
+    #[tokio::test]
+    async fn test_scale_up_periodic_workload(tls_enabled: bool) {
+        // Requests of 15 bytes every 100 milliseconds should result in 300 bytes of traffic (150
+        // bytes sent, 150 bytes received) every second. This exceeds the scale_up_threshold of 299
+        // bytes/s.
+        let scale_up_threshold = 299;
+        let num_requests = 60;
+        let request_size = 30;
+        let request_interval_millis = 100;
+
+        let service = TestService::new_with_partition_count_and_scale_up_threshold(
+            1,
+            scale_up_threshold,
+            tls_enabled,
+        )
+        .await;
+
+        let mut proxy = ProxyUnderTest::new(tls_enabled, service.listen_port).await;
+
+        let mut client = TestClient::new(proxy.listen_port).await;
+        for _ in 0..num_requests {
+            client.send_message_with_size(request_size).await.unwrap();
+            tokio::time::sleep(Duration::from_millis(request_interval_millis)).await;
+        }
+
+        proxy
+            .poll_scale_up()
+            .await
+            .expect("Timeout exceeded while awaiting scale up");
+
+        service.shutdown().await;
+    }
+
+    #[test_case(true; "tls enabled")]
+    #[test_case(false; "tls disabled")]
+    #[tokio::test]
+    async fn test_no_scale_up_periodic_workload(tls_enabled: bool) {
+        // Requests of 10 bytes every 100 milliseconds should result in 200 bytes of traffic (100
+        // bytes sent, 100 bytes received) every seconds. This does not exceeds the
+        // scale_up_threshold of 300 bytes/s.
+        //
+        let scale_up_threshold = 300;
+        let num_requests = 60;
+        let request_size = 10;
+        let request_interval_millis = 100;
+
+        let service = TestService::new_with_partition_count_and_scale_up_threshold(
+            1,
+            scale_up_threshold,
+            tls_enabled,
+        )
+        .await;
+        let mut proxy = ProxyUnderTest::new(tls_enabled, service.listen_port).await;
+
+        // Only requests proxied within the monitoring window will be considered when determining
+        // when to scale up. The following requests should not result in a scale up attempt.
+        //
+        let mut client = TestClient::new(proxy.listen_port).await;
+        for _ in 0..num_requests {
+            client.send_message_with_size(request_size).await.unwrap();
+            tokio::time::sleep(Duration::from_millis(request_interval_millis)).await;
+        }
+
+        proxy
+            .poll_scale_up()
+            .await
+            .expect_err("Unexpected Scale Up");
+
+        service.shutdown().await;
+    }
+
+    #[test_case(true; "tls enabled")]
+    #[test_case(false; "tls disabled")]
+    #[tokio::test]
+    async fn test_scale_up_new_partition(tls_enabled: bool) {
+        let service = TestService::new_with_throughput_scale_up_threshold(
+            TestService::ALWAYS_SCALE_UP_THRESHOLD_BYTES_PER_SEC,
+            tls_enabled,
+        )
+        .await;
+        let mut proxy = ProxyUnderTest::new(tls_enabled, service.listen_port).await;
+
+        // A request from the client will cause the proxy to establish an addition connection to
+        // the NFS server
+        //
+        let mut client = TestClient::new(proxy.listen_port).await;
+        client.send_message_with_size(10).await.unwrap();
+
+        let report = proxy.get_report().await;
+        let initial_partition_id = report.partition_id.expect("No PartitionId");
+
+        service
+            .post_action(ServiceAction::StopPartitionAcceptor(initial_partition_id))
+            .await;
+
+        // After scale up, we need to wait for the controller to reset and to listen to a new
+        // connection from the client
+        //
+        tokio::time::sleep(Duration::from_secs(5)).await;
+
+        let mut new_client = TestClient::new(proxy.listen_port).await;
+        new_client.send_message_with_size(10).await.unwrap();
+
+        proxy
+            .poll_scale_up()
+            .await
+            .expect("Timeout exceeded while awaiting scale up");
+
+        let connection_state = proxy.get_report().await.connection_state;
+        assert_eq!(ConnectionSearchState::Idle, connection_state);
+
+        service.shutdown().await;
+    }
+
+    #[test_case(true; "tls enabled")]
+    #[test_case(false; "tls disabled")]
+    #[tokio::test]
+    async fn test_successful_scale_up_with_retries(tls_enabled: bool) {
+        let scale_up_threshold = 10;
+        let service = TestService::new_with_partition_count_and_scale_up_threshold(
+            1,
+            scale_up_threshold,
+            tls_enabled,
+        )
+        .await;
+        let mut proxy = ProxyUnderTest::new(tls_enabled, service.listen_port).await;
+
+        // A request from the client will cause the proxy to establish an addition connection to the NFS server
+        let mut client = TestClient::new(proxy.listen_port).await;
+        client.send_message_with_size(5).await.unwrap();
+
+        service
+            .post_action(ServiceAction::SendRetries(std::cmp::min(
+                5,
+                crate::connections::MAX_ATTEMPT_COUNT - 5,
+            )))
+            .await;
+
+        client.send_message_with_size(100).await.unwrap();
+
+        proxy
+            .poll_scale_up()
+            .await
+            .expect("Timeout exceeded while awaiting scale up");
+
+        service.shutdown().await;
+    }
+
+    #[test_case(true; "tls enabled")]
+    #[test_case(false; "tls disabled")]
+    #[tokio::test]
+    async fn test_no_scale_up_threshold_not_exceed(tls_enabled: bool) {
+        let service = TestService::new_with_throughput_scale_up_threshold(
+            TestService::NEVER_SCALE_UP_THRESHOLD_BYTES_PER_SEC,
+            tls_enabled,
+        )
+        .await;
+        let mut proxy = ProxyUnderTest::new(tls_enabled, service.listen_port).await;
+
+        // Requests from the client below the throughput threshold should not cause new connections
+        // to the NFS server to be established
+        let mut client = TestClient::new(proxy.listen_port).await;
+        client.send_message_with_size(10).await.unwrap();
+
+        proxy
+            .poll_scale_up()
+            .await
+            .expect_err("Unexpected scale up occured");
+
+        let connection_state = proxy.get_report().await.connection_state;
+        assert_eq!(ConnectionSearchState::Idle, connection_state);
+
+        service.shutdown().await;
+    }
+
+    #[test_case(true; "tls enabled")]
+    #[test_case(false; "tls disabled")]
+    #[tokio::test]
+    async fn test_no_scale_up_if_already_scaled_up(tls_enabled: bool) {
+        let scale_up_threshold = 10;
+        let service = TestService::new_with_partition_count_and_scale_up_threshold(
+            5,
+            scale_up_threshold,
+            tls_enabled,
+        )
+        .await;
+
+        let mut proxy = ProxyUnderTest::new(tls_enabled, service.listen_port).await;
+
+        // Requests from the client below the throughput threshold should not cause scale up
+        let mut client = TestClient::new(proxy.listen_port).await;
+        client
+            .send_message_with_size((scale_up_threshold - 1) as usize)
+            .await
+            .unwrap();
+
+        // Stop initial partition so that the proxy resets after scale up
+        let initial_report = proxy.get_report().await;
+        let initial_partition_id = initial_report.partition_id.expect("No PartitionId");
+        assert_eq!(0, initial_report.scale_up_attempt_count);
+        assert_eq!(0, initial_report.restart_count);
+
+        service
+            .post_action(ServiceAction::StopPartitionAcceptor(initial_partition_id))
+            .await;
+
+        // This requests should cause scale up to be attempted
+        client
+            .send_message_with_size((scale_up_threshold + 10) as usize)
+            .await
+            .unwrap();
+
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        let mut client = TestClient::new(proxy.listen_port).await;
+        client
+            .send_message_with_size((scale_up_threshold - 1) as usize)
+            .await
+            .unwrap();
+
+        proxy
+            .poll_scale_up()
+            .await
+            .expect("Timeout exceeded while awaiting scale up");
+
+        let second_report = proxy.get_report().await;
+        assert_eq!(ConnectionSearchState::Idle, second_report.connection_state);
+        assert_eq!(
+            DEFAULT_SCALE_UP_CONFIG.max_multiplexed_connections as usize,
+            second_report.num_connections
+        );
+        assert_eq!(1, second_report.scale_up_attempt_count);
+        assert_eq!(1, second_report.restart_count);
+
+        // Additional requests from the client should not cause additional scale up attempts
+        for _ in 0..5 {
+            client
+                .send_message_with_size((scale_up_threshold + 10) as usize)
+                .await
+                .unwrap();
+            tokio::time::sleep(Duration::from_secs(1)).await;
+        }
+
+        let third_report = proxy.get_report().await;
+        assert_eq!(ConnectionSearchState::Idle, third_report.connection_state);
+        assert_eq!(
+            DEFAULT_SCALE_UP_CONFIG.max_multiplexed_connections as usize,
+            third_report.num_connections
+        );
+        assert_eq!(1, third_report.scale_up_attempt_count);
+        assert_eq!(1, third_report.restart_count);
+
+        service.shutdown().await;
+    }
+
+    #[test_case(true; "tls enabled")]
+    #[test_case(false; "tls disabled")]
+    #[tokio::test]
+    async fn test_scale_up_failed_too_many_retries(tls_enabled: bool) {
+        // Use a single partition so that the same PartitionId is return on each
+        // bind_client_to_partition request. This prevents a controller "reset", which simplifies
+        // testing that the proxy will retry scale up after the backoff time as elapsed.
+        //
+        let scale_up_threshold = 10;
+        let service = TestService::new_with_partition_count_and_scale_up_threshold(
+            1,
+            scale_up_threshold,
+            tls_enabled,
+        )
+        .await;
+
+        let mut proxy = ProxyUnderTest::new(tls_enabled, service.listen_port).await;
+
+        let mut client = TestClient::new(proxy.listen_port).await;
+
+        // Send an initial request in which the bind_client_to_partition request succeeds, and the
+        // main controller loop starts, but scale up is not requested
+        //
+        client
+            .send_message_with_size((scale_up_threshold - 1) as usize)
+            .await
+            .unwrap();
+
+        // Update the server to return BindResponse::RETRY until scale up attempt fails
+        service
+            .post_action(ServiceAction::SendRetries(
+                crate::connections::MAX_ATTEMPT_COUNT + 1,
+            ))
+            .await;
+
+        // This request will cause the proxy to attempt scale up, in which bind_client_to_partition
+        // requests will fail
+        //
+        client.send_message_with_size(100).await.unwrap();
+
+        // Wait for scale up to fail
+        tokio::time::sleep(Duration::from_secs(5)).await;
+
+        // Expect that scale up does not occur
+        proxy
+            .poll_scale_up()
+            .await
+            .expect_err("Unexpected scale up occured");
+
+        let report = proxy.get_report().await;
+        assert!(matches!(
+            report.connection_state,
+            ConnectionSearchState::Stop(_)
+        ));
+
+        // Advance time and assert that scale up occurs after backoff duration elapsed
+        tokio::time::pause();
+        tokio::time::advance(
+            DEFAULT_SCALE_UP_BACKOFF + Duration::from_secs(MULTIPLEX_CONNECTION_TIMEOUT_SEC),
+        )
+        .await;
+        tokio::time::resume();
+
+        service.post_action(ServiceAction::EnableScaleUp).await;
+        client.send_message_with_size(100).await.unwrap();
+
+        proxy.poll_scale_up().await.expect("Scale up failed");
+
+        let connection_state = proxy.get_report().await.connection_state;
+        assert_eq!(ConnectionSearchState::Idle, connection_state);
+
+        service.shutdown().await;
+    }
+
+    #[test_case(true; "tls enabled")]
+    #[test_case(false; "tls disabled")]
+    #[tokio::test]
+    async fn test_scale_up_failed_retry_later(tls_enabled: bool) {
+        // Use a single partition so that the same PartitionId is return on each
+        // bind_client_to_partition request. This prevents a controller "reset", which simplifies
+        // testing that the proxy will retry scale up after the backoff time as elapsed.
+        //
+        let scale_up_threshold = 10;
+        let service = TestService::new_with_partition_count_and_scale_up_threshold(
+            1,
+            scale_up_threshold,
+            tls_enabled,
+        )
+        .await;
+
+        let mut proxy = ProxyUnderTest::new(tls_enabled, service.listen_port).await;
+
+        let mut client = TestClient::new(proxy.listen_port).await;
+
+        // Send an initial request in which the bind_client_to_partition request succeeds, and the
+        // main controller loop starts, but scale up is not requested
+        //
+        client
+            .send_message_with_size((scale_up_threshold - 1) as usize)
+            .await
+            .unwrap();
+
+        // Update the server to return BindResponse::RETRY_LATER on the next bind_client_to_partition rpc
+        // request
+        //
+        service.post_action(ServiceAction::DisableScaleUp).await;
+
+        // This request will cause the proxy to attempt scale up, in which bind_client_to_partition
+        // requests will fail
+        //
+        client
+            .send_message_with_size((scale_up_threshold) as usize)
+            .await
+            .unwrap();
+
+        // Expect that scale up does not occur
+        proxy
+            .poll_scale_up()
+            .await
+            .expect_err("Unexpected scale up occured");
+
+        let report = proxy.get_report().await;
+        assert!(matches!(
+            report.connection_state,
+            ConnectionSearchState::Stop(_)
+        ));
+
+        // Advance time and assert that scale up occurs after backoff duration elapsed
+        tokio::time::pause();
+        tokio::time::advance(
+            DEFAULT_SCALE_UP_BACKOFF + Duration::from_secs(MULTIPLEX_CONNECTION_TIMEOUT_SEC),
+        )
+        .await;
+        tokio::time::resume();
+
+        service.post_action(ServiceAction::EnableScaleUp).await;
+        client
+            .send_message_with_size(
+                (scale_up_threshold * proxy::REPORT_INTERVAL_SECS as i32) as usize,
+            )
+            .await
+            .unwrap();
+
+        proxy.poll_scale_up().await.expect("Scale up failed");
+
+        let connection_state = proxy.get_report().await.connection_state;
+        assert_eq!(ConnectionSearchState::Idle, connection_state);
+
+        service.shutdown().await;
+    }
+
+    #[test_case(true; "tls enabled")]
+    #[test_case(false; "tls disabled")]
+    #[tokio::test]
+    async fn test_scale_up_connection_usage(tls_enabled: bool) {
+        // Prevent controller reset after scale up by using existing partition
+        let service = TestService::new_with_partition_count_and_scale_up_threshold(
+            1,
+            TestService::ALWAYS_SCALE_UP_THRESHOLD_BYTES_PER_SEC,
+            tls_enabled,
+        )
+        .await;
+
+        let mut proxy = ProxyUnderTest::new(tls_enabled, service.listen_port).await;
+
+        let mut client = TestClient::new(proxy.listen_port).await;
+        client.send_message_with_size(10).await.unwrap();
+
+        proxy
+            .poll_scale_up()
+            .await
+            .expect("Timeout exceeded while awaiting scale up");
+
+        let request_to_send_per_connection = 10;
+        for _ in
+            0..(request_to_send_per_connection * proxy.scale_up_config.max_multiplexed_connections)
+        {
+            client.send_message_with_size(10).await.unwrap();
+        }
+
+        // Check that requests are routed over multiple connections
+        let partition_id = proxy
+            .get_report()
+            .await
+            .partition_id
+            .expect("Missing PartitionId");
+
+        let request_counter = service.request_counter.lock().await;
+        let counts = request_counter
+            .get(&partition_id)
+            .expect("Missing request counts");
+
+        assert!(counts.len() >= proxy.scale_up_config.max_multiplexed_connections as usize);
+        for count in counts {
+            let operation_count = count.load(std::sync::atomic::Ordering::Acquire);
+            // Unused connections to a partition can be established during connection search. For
+            // this connections, the operation count will be 1
+            //
+            assert!(
+                operation_count >= request_to_send_per_connection as u32 || operation_count == 1
+            );
+        }
+
+        drop(request_counter);
+        service.shutdown().await;
+    }
+
+    #[test_case(true; "tls enabled")]
+    #[tokio::test]
+    async fn test_efs_utils_port_test(tls_enabled: bool) {
+        let service = TestService::new(tls_enabled).await;
+        let mut proxy = ProxyUnderTest::new(tls_enabled, service.listen_port).await;
+        let mut port_health_check = TestClient::new(proxy.listen_port).await;
+        // Mimic efs-utils's port test which checks whether efs-proxy is alive.
+        let _ = port_health_check.stream.shutdown().await.unwrap();
+        let mut client = TestClient::new(proxy.listen_port).await;
+        client.send_message_with_size(10).await.unwrap();
+        client.send_message_with_size(1024).await.unwrap();
+
+        let report = proxy.get_report().await;
+        assert!(report.partition_id.is_some());
+
+        service.shutdown().await;
+    }
+}

--- a/src/proxy/src/efs_prot.x
+++ b/src/proxy/src/efs_prot.x
@@ -1,0 +1,57 @@
+/*
+* EFS program V1
+*/
+
+const PROXY_ID_LENGTH = 16;
+const PROXY_INCARNATION_LENGTH = 8;
+const PARTITION_ID_LENGTH = 64;
+
+enum OperationType {
+    OP_BIND_CLIENT_TO_PARTITION = 1
+};
+
+typedef opaque PartitionId[PARTITION_ID_LENGTH];
+
+struct ProxyIdentifier {
+    opaque identifier<PROXY_ID_LENGTH>;
+    opaque incarnation<PROXY_INCARNATION_LENGTH>;
+};
+
+struct ScaleUpConfig {
+    int max_multiplexed_connections;
+    int scale_up_bytes_per_sec_threshold;
+    int scale_up_threshold_breached_duration_sec;
+};
+
+enum BindResponseType {
+    RETRY = 0,
+    RETRY_LATER = 1,
+    PREFERRED = 2,
+    READY = 3,
+    ERROR = 4
+};
+
+union BindResponse switch (BindResponseType type) {
+    case PREFERRED:
+    case READY:
+        PartitionId partition_id;
+    case RETRY:
+    case RETRY_LATER:
+        String stop_msg;
+    case ERROR:
+        String error_msg;
+    default:
+        void;
+};
+
+struct BindClientResponse {
+    BindResponse bind_response;
+    ScaleUpConfig scale_up_config;
+};
+
+union OperationResponse switch (OperationType operation_type) {
+    case OP_BIND_CLIENT_TO_PARTITION:
+        BindClientResponse response;
+    default:
+        void;
+};

--- a/src/proxy/src/efs_rpc.rs
+++ b/src/proxy/src/efs_rpc.rs
@@ -1,0 +1,318 @@
+use std::io::Cursor;
+use tokio::io::AsyncWriteExt;
+
+use crate::connections::ProxyStream;
+use crate::efs_prot;
+use crate::efs_prot::BindClientResponse;
+use crate::efs_prot::OperationType;
+use crate::error::RpcError;
+use crate::proxy_identifier::ProxyIdentifier;
+use crate::rpc;
+
+const PROGRAM_NUMBER: u32 = 100200;
+const PROGRAM_VERSION: u32 = 1;
+
+#[derive(Copy, Clone, Debug, Eq, Hash, PartialEq)]
+pub struct PartitionId {
+    pub id: [u8; 64],
+}
+
+pub async fn bind_client_to_partition(
+    proxy_id: ProxyIdentifier,
+    stream: &mut dyn ProxyStream,
+) -> Result<BindClientResponse, RpcError> {
+    let request = create_bind_client_to_partition_request(&proxy_id)?;
+    stream.write_all(&request).await?;
+    stream.flush().await?;
+
+    let response_bytes = rpc::read_rpc_bytes(stream).await?;
+    let response = onc_rpc::RpcMessage::try_from(response_bytes.as_slice())?;
+
+    parse_bind_client_to_partition_response(&response)
+}
+
+pub fn create_bind_client_to_partition_request(
+    proxy_id: &ProxyIdentifier,
+) -> Result<Vec<u8>, RpcError> {
+    let payload = efs_prot::ProxyIdentifier {
+        identifier: proxy_id.uuid.as_bytes().to_vec(),
+        incarnation: proxy_id.incarnation.to_be_bytes().to_vec(),
+    };
+    let mut payload_buf = Vec::new();
+    xdr_codec::pack(&payload, &mut payload_buf)?;
+
+    let call_body = onc_rpc::CallBody::new(
+        PROGRAM_NUMBER,
+        PROGRAM_VERSION,
+        OperationType::OP_BIND_CLIENT_TO_PARTITION as u32,
+        onc_rpc::auth::AuthFlavor::AuthNone::<Vec<_>>(None),
+        onc_rpc::auth::AuthFlavor::AuthNone::<Vec<_>>(None),
+        payload_buf,
+    );
+
+    let xid = rand::random::<u32>();
+    onc_rpc::RpcMessage::new(xid, onc_rpc::MessageType::Call(call_body))
+        .serialise()
+        .map_err(|e| e.into())
+}
+
+pub fn parse_bind_client_to_partition_response(
+    response: &onc_rpc::RpcMessage<&[u8], &[u8]>,
+) -> Result<BindClientResponse, RpcError> {
+    let Some(reply_body) = response.reply_body() else {
+        Err(RpcError::MalformedResponse)?
+    };
+
+    let accepted_status = match reply_body {
+        onc_rpc::ReplyBody::Accepted(reply) => reply.status(),
+        onc_rpc::ReplyBody::Denied(_m) => Err(RpcError::Denied)?,
+    };
+
+    let payload = match accepted_status {
+        onc_rpc::AcceptedStatus::Success(p) => p,
+        onc_rpc::AcceptedStatus::GarbageArgs => Err(RpcError::GarbageArgs)?,
+        onc_rpc::AcceptedStatus::ProgramUnavailable => Err(RpcError::ProgramUnavailable)?,
+        onc_rpc::AcceptedStatus::ProgramMismatch { low, high } => Err(RpcError::ProgramMismatch {
+            low: *low,
+            high: *high,
+        })?,
+        onc_rpc::AcceptedStatus::ProcedureUnavailable => Err(RpcError::ProcedureUnavailable)?,
+        onc_rpc::AcceptedStatus::SystemError => Err(RpcError::SystemError)?,
+    };
+
+    xdr_codec::unpack::<_, BindClientResponse>(&mut Cursor::new(payload)).map_err(|e| e.into())
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::controller::tests::TestService;
+    use crate::controller::DEFAULT_SCALE_UP_CONFIG;
+    use crate::efs_prot::BindResponse;
+    use crate::efs_prot::ScaleUpConfig;
+    use crate::tls::tests::get_client_config;
+    use onc_rpc::{AuthError, RejectedReply};
+    use rand::RngCore;
+    use s2n_tls_tokio::TlsConnector;
+    use tokio::net::TcpStream;
+
+    const XID: u32 = 1;
+
+    pub fn parse_bind_client_to_partition_request(
+        request: &onc_rpc::RpcMessage<&[u8], &[u8]>,
+    ) -> Result<ProxyIdentifier, RpcError> {
+        let call_body = request.call_body().expect("not a call rpc");
+
+        if PROGRAM_NUMBER != call_body.program() || PROGRAM_VERSION != call_body.program_version() {
+            return Err(RpcError::GarbageArgs);
+        }
+
+        let mut payload = Cursor::new(call_body.payload());
+        let raw_proxy_id = xdr_codec::unpack::<_, efs_prot::ProxyIdentifier>(&mut payload)?;
+
+        Ok(ProxyIdentifier {
+            uuid: uuid::Builder::from_bytes(
+                raw_proxy_id
+                    .identifier
+                    .try_into()
+                    .expect("Failed not convert vec to sized array"),
+            )
+            .into_uuid(),
+            incarnation: i64::from_be_bytes(
+                raw_proxy_id
+                    .incarnation
+                    .try_into()
+                    .expect("Failed to convert vec to sized array"),
+            ),
+        })
+    }
+
+    pub fn create_bind_client_to_partition_response(
+        xid: u32,
+        bind_response: BindResponse,
+        scale_up_config: ScaleUpConfig,
+    ) -> Result<Vec<u8>, RpcError> {
+        let mut payload_buf = Vec::new();
+
+        let response = BindClientResponse {
+            bind_response: bind_response,
+            scale_up_config: scale_up_config,
+        };
+        xdr_codec::pack(&response, &mut payload_buf)?;
+
+        create_bind_client_to_partition_response_from_accepted_status(
+            xid,
+            onc_rpc::AcceptedStatus::Success(payload_buf),
+        )
+    }
+
+    pub fn create_bind_client_to_partition_response_from_accepted_status(
+        xid: u32,
+        accepted_status: onc_rpc::AcceptedStatus<Vec<u8>>,
+    ) -> Result<Vec<u8>, RpcError> {
+        let reply_body = onc_rpc::ReplyBody::Accepted(onc_rpc::AcceptedReply::new(
+            onc_rpc::auth::AuthFlavor::AuthNone::<Vec<_>>(None),
+            accepted_status,
+        ));
+
+        onc_rpc::RpcMessage::new(xid, onc_rpc::MessageType::Reply(reply_body))
+            .serialise()
+            .map_err(|e| e.into())
+    }
+
+    fn generate_parse_bind_client_to_partition_response_result(
+        accepted_status: onc_rpc::AcceptedStatus<Vec<u8>>,
+    ) -> Result<BindClientResponse, RpcError> {
+        let response =
+            create_bind_client_to_partition_response_from_accepted_status(XID, accepted_status)?;
+        let deserialized = onc_rpc::RpcMessage::try_from(response.as_slice())?;
+        parse_bind_client_to_partition_response(&deserialized)
+    }
+
+    pub fn generate_partition_id() -> efs_prot::PartitionId {
+        let mut bytes = [0u8; efs_prot::PARTITION_ID_LENGTH as usize];
+        rand::thread_rng().fill_bytes(&mut bytes);
+        efs_prot::PartitionId(bytes)
+    }
+
+    #[tokio::test]
+    async fn test_bind_client_to_partition() {
+        let server = TestService::new(true).await;
+        let tcp_stream = TcpStream::connect(("127.0.0.1", server.listen_port))
+            .await
+            .expect("Could not connect to test server.");
+
+        let connector =
+            TlsConnector::new(get_client_config().await.expect("Failed to read config"));
+        let mut tls_stream = connector
+            .connect("localhost", tcp_stream)
+            .await
+            .expect("Failed to establish TLS Connection");
+
+        let response = bind_client_to_partition(ProxyIdentifier::new(), &mut tls_stream)
+            .await
+            .expect("bind_client_to_partition request failed");
+
+        let partition_id = match response.bind_response {
+            BindResponse::READY(id) => PartitionId { id: id.0 },
+            _ => panic!(),
+        };
+
+        assert_eq!(
+            server
+                .partition_ids
+                .get(1)
+                .expect("Service has no partition IDs"),
+            &partition_id
+        );
+        server.shutdown().await;
+    }
+
+    #[test]
+    fn test_request_serde() -> Result<(), RpcError> {
+        let proxy_id = ProxyIdentifier::new();
+        let request = create_bind_client_to_partition_request(&proxy_id)?;
+
+        let deserialized = onc_rpc::RpcMessage::try_from(request.as_slice())?;
+        let deserialized_proxy_id = parse_bind_client_to_partition_request(&deserialized)?;
+
+        assert_eq!(proxy_id.uuid, deserialized_proxy_id.uuid);
+        assert_eq!(proxy_id.incarnation, deserialized_proxy_id.incarnation);
+        Ok(())
+    }
+
+    #[test]
+    fn test_response_serde() -> Result<(), RpcError> {
+        let partition_id = generate_partition_id();
+        let partition_id_copy = efs_prot::PartitionId(partition_id.0.clone());
+
+        let response = create_bind_client_to_partition_response(
+            XID,
+            BindResponse::READY(partition_id_copy),
+            DEFAULT_SCALE_UP_CONFIG,
+        )?;
+
+        let deserialized = onc_rpc::RpcMessage::try_from(response.as_slice())?;
+        let deserialized_response = parse_bind_client_to_partition_response(&deserialized)?;
+
+        assert!(
+            matches!(deserialized_response.bind_response, BindResponse::READY(id) if id.0 == partition_id.0)
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_bind_client_to_partition_response_missing_reply() -> Result<(), RpcError> {
+        // Create a call message, which will error when parsed as a response
+        let malformed_response = create_bind_client_to_partition_request(&ProxyIdentifier::new())?;
+        let deserialized = onc_rpc::RpcMessage::try_from(malformed_response.as_slice())?;
+
+        let result = parse_bind_client_to_partition_response(&deserialized);
+        assert!(matches!(result, Err(RpcError::MalformedResponse)));
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_bind_client_to_partition_response_denied() -> Result<(), RpcError> {
+        let reply_body =
+            onc_rpc::ReplyBody::Denied(RejectedReply::AuthError(AuthError::BadCredentials));
+        let rpc_message = onc_rpc::RpcMessage::new(XID, onc_rpc::MessageType::Reply(reply_body));
+
+        let result = parse_bind_client_to_partition_response(&rpc_message);
+        assert!(matches!(result, Err(RpcError::Denied)));
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_bind_client_to_partition_response_garbage_args() -> Result<(), RpcError> {
+        let parse_result = generate_parse_bind_client_to_partition_response_result(
+            onc_rpc::AcceptedStatus::GarbageArgs,
+        );
+        assert!(matches!(parse_result, Err(RpcError::GarbageArgs)));
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_bind_client_to_partition_response_program_unavailable() -> Result<(), RpcError> {
+        let parse_result = generate_parse_bind_client_to_partition_response_result(
+            onc_rpc::AcceptedStatus::ProcedureUnavailable,
+        );
+        assert!(matches!(parse_result, Err(RpcError::ProcedureUnavailable)));
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_bind_client_to_partition_response_program_mismatch() -> Result<(), RpcError> {
+        let program_version_low = 10;
+        let program_version_high = 100;
+        let parse_result = generate_parse_bind_client_to_partition_response_result(
+            onc_rpc::AcceptedStatus::ProgramMismatch {
+                low: program_version_low,
+                high: program_version_high,
+            },
+        );
+        assert!(matches!(
+            parse_result,
+            Err(RpcError::ProgramMismatch { low: l, high: h }) if program_version_low == l && program_version_high == h));
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_bind_client_to_partition_response_procedure_unavailable() -> Result<(), RpcError>
+    {
+        let parse_result = generate_parse_bind_client_to_partition_response_result(
+            onc_rpc::AcceptedStatus::ProcedureUnavailable,
+        );
+        assert!(matches!(parse_result, Err(RpcError::ProcedureUnavailable)));
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_bind_client_to_partition_response_system_error() -> Result<(), RpcError> {
+        let parse_result = generate_parse_bind_client_to_partition_response_result(
+            onc_rpc::AcceptedStatus::SystemError,
+        );
+        assert!(matches!(parse_result, Err(RpcError::SystemError)));
+        Ok(())
+    }
+}

--- a/src/proxy/src/error.rs
+++ b/src/proxy/src/error.rs
@@ -1,0 +1,41 @@
+use thiserror::Error as ThisError;
+
+#[derive(Debug, ThisError)]
+pub enum ConnectError {
+    #[error("Connect attempt cancelled")]
+    Cancelled,
+    #[error("{0}")]
+    IoError(#[from] tokio::io::Error),
+    #[error("Connect attempt failed - Maximum attempt count exceeded")]
+    MaxAttemptsExceeded,
+    #[error("Attempt to acquire additional connections to EFS failed.")]
+    MultiplexFailure,
+    #[error(transparent)]
+    Tls(#[from] s2n_tls::error::Error),
+    #[error("Connect attempt failed - Timeout")]
+    Timeout,
+}
+
+#[derive(Debug, ThisError)]
+pub enum RpcError {
+    #[error("not a rpc response")]
+    MalformedResponse,
+    #[error("rpc reply_stat: MSG_DENIED")]
+    Denied,
+    #[error("rpc accept_stat: GARBAGE_ARGS")]
+    GarbageArgs,
+    #[error("rpc accept_stat: PROG_UNAVAIL")]
+    ProgramUnavailable,
+    #[error("rpc accept_stat: PROG_MISMATCH low: {} high: {}", .low, .high)]
+    ProgramMismatch { low: u32, high: u32 },
+    #[error("rpc accept_stat: PROC_UNAVAIL")]
+    ProcedureUnavailable,
+    #[error("rpc accept_stat: SystemError")]
+    SystemError,
+    #[error(transparent)]
+    IoError(#[from] tokio::io::Error),
+    #[error(transparent)]
+    XdrCodecError(#[from] xdr_codec::Error),
+    #[error(transparent)]
+    OncRpc(#[from] onc_rpc::Error),
+}

--- a/src/proxy/src/lib.rs
+++ b/src/proxy/src/lib.rs
@@ -1,0 +1,4 @@
+//! One-sentence summary of your crate.
+//!
+//! Followed by more detailed Markdown documentation of your crate.
+#![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]

--- a/src/proxy/src/logger.rs
+++ b/src/proxy/src/logger.rs
@@ -1,0 +1,65 @@
+use log::LevelFilter;
+use log4rs::{
+    append::{
+        console::{ConsoleAppender, Target},
+        rolling_file::{
+            policy::compound::{
+                roll::fixed_window::FixedWindowRoller, trigger::size::SizeTrigger, CompoundPolicy,
+            },
+            RollingFileAppender,
+        },
+    },
+    config::{Appender, Config, Root},
+    encode::pattern::PatternEncoder,
+    filter::threshold::ThresholdFilter,
+};
+use std::{path::Path, str::FromStr};
+
+use crate::config_parser::ProxyConfig;
+
+const LOG_FILE_MAX_BYTES: u64 = 1048576;
+const LOG_FILE_COUNT: u32 = 10;
+
+pub fn init(config: &ProxyConfig) {
+    let log_file_path_string = config
+        .output
+        .clone()
+        .expect("config value `output` is not set");
+    let log_file_path = Path::new(&log_file_path_string);
+    let level_filter =
+        LevelFilter::from_str(&config.debug).expect("config value for `debug` is invalid");
+
+    let stderr = ConsoleAppender::builder().target(Target::Stderr).build();
+
+    let trigger = SizeTrigger::new(LOG_FILE_MAX_BYTES);
+    let mut pattern = log_file_path_string.clone();
+    pattern.push_str(".{}");
+    let roller = FixedWindowRoller::builder()
+        .build(&pattern, LOG_FILE_COUNT)
+        .expect("Unable to create roller");
+    let policy = CompoundPolicy::new(Box::new(trigger), Box::new(roller));
+
+    let log_file = RollingFileAppender::builder()
+        .encoder(Box::new(PatternEncoder::new(
+            "{d(%Y-%m-%dT%H:%M:%S%.3fZ)(utc)} {l} {M} {m}{n}",
+        )))
+        .build(log_file_path, Box::new(policy))
+        .expect("Unable to create log file");
+
+    let config = Config::builder()
+        .appender(Appender::builder().build("logfile", Box::new(log_file)))
+        .appender(
+            Appender::builder()
+                .filter(Box::new(ThresholdFilter::new(LevelFilter::Error)))
+                .build("stderr", Box::new(stderr)),
+        )
+        .build(
+            Root::builder()
+                .appender("logfile")
+                .appender("stderr")
+                .build(level_filter),
+        )
+        .expect("Invalid logger config");
+
+    let _ = log4rs::init_config(config).expect("Unable to initialize logger");
+}

--- a/src/proxy/src/main.rs
+++ b/src/proxy/src/main.rs
@@ -1,0 +1,138 @@
+use crate::config_parser::ProxyConfig;
+use crate::connections::{PlainTextPartitionFinder, TlsPartitionFinder};
+use crate::tls::TlsConfig;
+use clap::Parser;
+use controller::Controller;
+use log::{debug, error, info};
+use std::path::Path;
+use std::sync::Arc;
+use tokio::signal;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+mod config_parser;
+mod connections;
+mod controller;
+mod efs_rpc;
+mod error;
+mod logger;
+mod proxy;
+mod proxy_identifier;
+mod rpc;
+mod shutdown;
+mod status_reporter;
+mod tls;
+
+#[allow(clippy::all)]
+#[allow(deprecated)]
+#[allow(invalid_value)]
+#[allow(non_camel_case_types)]
+#[allow(unused_assignments)]
+mod efs_prot {
+    include!(concat!(env!("OUT_DIR"), "/efs_prot_xdr.rs"));
+}
+
+#[tokio::main]
+async fn main() {
+    let args = Args::parse();
+
+    let proxy_config = match ProxyConfig::from_path(Path::new(&args.proxy_config_path)) {
+        Ok(config) => config,
+        Err(e) => panic!("Failed to read configuration. {}", e),
+    };
+
+    if let Some(_log_file_path) = &proxy_config.output {
+        logger::init(&proxy_config)
+    }
+
+    info!("Running with configuration: {:?}", proxy_config);
+
+    // This "status reporter" is currently only used in tests
+    let (_status_requester, status_reporter) = status_reporter::create_status_channel();
+
+    let sigterm_cancellation_token = CancellationToken::new();
+    let mut sigterm_listener = match signal::unix::signal(signal::unix::SignalKind::terminate()) {
+        Ok(listener) => listener,
+        Err(e) => panic!("Failed to create SIGTERM listener. {}", e),
+    };
+
+    let controller_handle = if args.tls {
+        let tls_config = match get_tls_config(&proxy_config).await {
+            Ok(config) => Arc::new(Mutex::new(config)),
+            Err(e) => panic!("Failed to obtain TLS config:{}", e),
+        };
+
+        run_sighup_handler(proxy_config.clone(), tls_config.clone());
+
+        let controller = Controller::new(
+            &proxy_config.nested_config.listen_addr,
+            Arc::new(TlsPartitionFinder::new(tls_config)),
+            status_reporter,
+        )
+        .await;
+        tokio::spawn(controller.run(sigterm_cancellation_token.clone()))
+    } else {
+        let controller = Controller::new(
+            &proxy_config.nested_config.listen_addr,
+            Arc::new(PlainTextPartitionFinder {
+                mount_target_addr: proxy_config.nested_config.mount_target_addr.clone(),
+            }),
+            status_reporter,
+        )
+        .await;
+        tokio::spawn(controller.run(sigterm_cancellation_token.clone()))
+    };
+
+    tokio::select! {
+        shutdown_reason = controller_handle => error!("Shutting down. {:?}", shutdown_reason),
+        _ = sigterm_listener.recv() => {
+            info!("Received SIGTERM");
+            sigterm_cancellation_token.cancel();
+        },
+    }
+}
+
+async fn get_tls_config(proxy_config: &ProxyConfig) -> Result<TlsConfig, anyhow::Error> {
+    let tls_config = TlsConfig::new(
+        proxy_config.fips,
+        Path::new(&proxy_config.nested_config.ca_file),
+        Path::new(&proxy_config.nested_config.client_cert_pem_file),
+        Path::new(&proxy_config.nested_config.client_private_key_pem_file),
+        &proxy_config.nested_config.mount_target_addr,
+        &proxy_config.nested_config.expected_server_hostname_tls,
+    )
+    .await;
+    let tls_config = tls_config?;
+    Ok(tls_config)
+}
+
+fn run_sighup_handler(proxy_config: ProxyConfig, tls_config: Arc<Mutex<TlsConfig>>) {
+    tokio::spawn(async move {
+        let mut sighup_listener = match signal::unix::signal(signal::unix::SignalKind::hangup()) {
+            Ok(listener) => listener,
+            Err(e) => panic!("Failed to create SIGHUP listener. {}", e),
+        };
+
+        loop {
+            sighup_listener
+                .recv()
+                .await
+                .expect("SIGHUP listener stream is closed");
+
+            debug!("Received SIGHUP");
+            let mut locked_config = tls_config.lock().await;
+            match get_tls_config(&proxy_config).await {
+                Ok(config) => *locked_config = config,
+                Err(e) => panic!("Failed to acquire TLS config. {}", e),
+            }
+        }
+    });
+}
+
+#[derive(Parser, Debug, Clone)]
+pub struct Args {
+    pub proxy_config_path: String,
+
+    #[arg(long, default_value_t = false)]
+    pub tls: bool,
+}

--- a/src/proxy/src/proxy.rs
+++ b/src/proxy/src/proxy.rs
@@ -1,0 +1,525 @@
+use std::{
+    error::Error,
+    marker::PhantomData,
+    sync::{atomic::AtomicU64, Arc},
+    time::{Duration, Instant},
+};
+
+use bytes::BytesMut;
+use log::{debug, error, info, trace};
+use tokio::{
+    io::{split, AsyncReadExt, AsyncWriteExt, ReadHalf, WriteHalf},
+    net::{
+        tcp::{OwnedReadHalf, OwnedWriteHalf},
+        TcpStream,
+    },
+    sync::{
+        mpsc::{self},
+        Mutex,
+    },
+    task::JoinHandle,
+};
+use tokio_util::sync::CancellationToken;
+
+use crate::rpc::{RpcFragmentParseError, RPC_MAX_SIZE};
+use crate::{
+    connections::ProxyStream,
+    controller::Event,
+    rpc::RpcBatch,
+    shutdown::{ShutdownHandle, ShutdownReason},
+};
+
+pub const REPORT_INTERVAL_SECS: u64 = 3;
+
+#[derive(Copy, Clone, Debug)]
+pub struct PerformanceStats {
+    _num_connections: usize,
+    pub read_bytes: u64,
+    pub write_bytes: u64,
+    pub time_delta: Duration,
+}
+
+impl PerformanceStats {
+    pub fn new(
+        num_connections: usize,
+        read_bytes: u64,
+        write_bytes: u64,
+        time_delta: Duration,
+    ) -> Self {
+        PerformanceStats {
+            _num_connections: num_connections,
+            read_bytes,
+            write_bytes,
+            time_delta,
+        }
+    }
+
+    // Return total throughput in bytes per second
+    pub fn get_total_throughput(&self) -> u64 {
+        let time_delta_seconds = self.time_delta.as_secs();
+        if time_delta_seconds == 0 {
+            0
+        } else {
+            let total_bytes = self.read_bytes + self.write_bytes;
+            total_bytes / time_delta_seconds
+        }
+    }
+}
+pub struct Proxy<S> {
+    partition_to_nfs_cli_queue: mpsc::Sender<ConnectionMessage>,
+    partition_senders: Arc<Mutex<Vec<mpsc::Sender<RpcBatch>>>>,
+    shutdown: ShutdownHandle,
+    proxy_task_handle: JoinHandle<()>,
+    phantom: PhantomData<S>,
+}
+
+impl<S: ProxyStream> Proxy<S> {
+    const SHUTDOWN_TIMEOUT: u64 = 15;
+
+    pub fn new(
+        nfs_client: TcpStream,
+        partition_servers: Vec<S>,
+        notification_queue: mpsc::Sender<Event<S>>,
+        shutdown: ShutdownHandle,
+    ) -> Self {
+        let (tx, rx) = mpsc::channel(64);
+
+        let senders = partition_servers
+            .into_iter()
+            .map(|stream| Proxy::create_connection(stream, tx.clone(), shutdown.clone()))
+            .collect::<Vec<mpsc::Sender<RpcBatch>>>();
+
+        let partition_senders = Arc::new(Mutex::new(senders));
+
+        let proxy = ProxyTask::new(
+            nfs_client,
+            notification_queue,
+            partition_senders.clone(),
+            rx,
+            shutdown.clone(),
+        );
+        let proxy_task_handle = tokio::spawn(proxy.run());
+        Self {
+            partition_to_nfs_cli_queue: tx,
+            partition_senders,
+            shutdown,
+            proxy_task_handle,
+            phantom: PhantomData,
+        }
+    }
+
+    pub async fn add_connection(&self, stream: S) {
+        let conn = Proxy::create_connection(
+            stream,
+            self.partition_to_nfs_cli_queue.clone(),
+            self.shutdown.clone(),
+        );
+        let mut f = self.partition_senders.lock().await;
+        f.push(conn);
+    }
+
+    fn create_connection(
+        stream: S,
+        proxy: mpsc::Sender<ConnectionMessage>,
+        shutdown: ShutdownHandle,
+    ) -> mpsc::Sender<RpcBatch> {
+        let (tx, rx) = mpsc::channel(64);
+        tokio::spawn(ConnectionTask::new(stream, rx, proxy).run(shutdown));
+        tx
+    }
+
+    pub async fn shutdown(self) -> Result<(), Box<dyn Error + Send + Sync>> {
+        self.shutdown.cancellation_token.cancel();
+        match tokio::time::timeout(
+            Duration::from_secs(Self::SHUTDOWN_TIMEOUT),
+            self.proxy_task_handle,
+        )
+        .await?
+        {
+            Ok(()) => Ok(()),
+            Err(join_err) => Err(join_err.into()),
+        }
+    }
+}
+
+const BUFFER_SIZE: usize = RPC_MAX_SIZE;
+
+struct ProxyTask<S> {
+    nfs_client: TcpStream,
+    notification_queue: mpsc::Sender<Event<S>>,
+    partition_senders: Arc<Mutex<Vec<mpsc::Sender<RpcBatch>>>>,
+    response_queue: mpsc::Receiver<ConnectionMessage>,
+    shutdown: ShutdownHandle,
+}
+
+enum ConnectionMessage {
+    Response(RpcBatch),
+}
+
+impl<S: ProxyStream> ProxyTask<S> {
+    pub fn new(
+        nfs_client: TcpStream,
+        notification_queue: mpsc::Sender<Event<S>>,
+        partition_senders: Arc<Mutex<Vec<mpsc::Sender<RpcBatch>>>>,
+        response_queue: mpsc::Receiver<ConnectionMessage>,
+        shutdown: ShutdownHandle,
+    ) -> Self {
+        Self {
+            nfs_client,
+            notification_queue,
+            partition_senders,
+            response_queue,
+            shutdown,
+        }
+    }
+
+    async fn run(self) {
+        // Runs Proxy between NFS Client and the EFS Service.
+        //
+        // This function returns when it is cancelled by the `ShutdownHandle`, or if an error
+        // causes the `ProxyTask`'s `reader`, `writer`, or `reporter` task to return. In any of
+        // these cases, the `tokio::select!` block will cancel all of the tasks run by this object.
+        //
+        // An unused `mspc::Sender` is passed to each task spawned, so that we can await task
+        // shutdown with `mspc::Receiver::recv`. See https://tokio.rs/tokio/topics/shutdown.
+
+        trace!("Starting proxy task");
+
+        let (shutdown_sender, mut shutdown_receiver) = mpsc::channel::<u8>(1);
+
+        let write_byte_count = Arc::new(AtomicU64::new(0));
+        let read_byte_count = Arc::new(AtomicU64::new(0));
+
+        let (read_half, write_half) = self.nfs_client.into_split();
+
+        let reader = Self::run_reader(
+            read_half,
+            read_byte_count.clone(),
+            self.partition_senders.clone(),
+            self.shutdown.clone(),
+            shutdown_sender.clone(),
+        );
+        let shutdown = self.shutdown.clone();
+        tokio::spawn(async move {
+            tokio::select! {
+                _ = reader => trace!("Proxy reader stopped"),
+                _ = shutdown.cancellation_token.cancelled() => trace!("Proxy reader stopped by ShutdownHandle"),
+            }
+        });
+
+        let writer = Self::run_writer(
+            write_half,
+            write_byte_count.clone(),
+            self.response_queue,
+            self.shutdown.clone(),
+            shutdown_sender.clone(),
+        );
+        let shutdown = self.shutdown.clone();
+        tokio::spawn(async move {
+            tokio::select! {
+                _ = writer => trace!("Proxy writer stopped"),
+                _ = shutdown.cancellation_token.cancelled() => trace!("Proxy writer stopped by ShutdownHandle"),
+            }
+        });
+
+        let reporter = Self::run_reporter(
+            read_byte_count,
+            write_byte_count,
+            self.partition_senders.clone(),
+            self.notification_queue.clone(),
+            shutdown_sender.clone(),
+        );
+        let shutdown = self.shutdown.clone();
+        tokio::spawn(async move {
+            tokio::select! {
+                _ = reporter => trace!("Proxy reporter stopped"),
+                _ = shutdown.cancellation_token.cancelled() => trace!("Proxy reporter stopped by ShutdownHandle"),
+            }
+        });
+
+        drop(shutdown_sender);
+        shutdown_receiver.recv().await;
+    }
+
+    // NFS client to Proxy
+    async fn run_reader(
+        mut read_half: OwnedReadHalf,
+        read_count: Arc<AtomicU64>,
+        partition_senders: Arc<Mutex<Vec<mpsc::Sender<RpcBatch>>>>,
+        shutdown: ShutdownHandle,
+        _shutdown_sender: mpsc::Sender<u8>,
+    ) {
+        trace!("Starting proxy reader");
+        let mut buffer = BytesMut::with_capacity(BUFFER_SIZE);
+        let reason;
+        let mut next_conn = 0;
+
+        loop {
+            match read_half.read_buf(&mut buffer).await {
+                Ok(n_read) => {
+                    if n_read == 0 {
+                        reason = Some(ShutdownReason::Unmount);
+                        break;
+                    } else {
+                        read_count.fetch_add(n_read as u64, std::sync::atomic::Ordering::AcqRel);
+                    }
+                }
+                Err(e) => {
+                    info!("Error reading from NFS client {:?}", e);
+                    reason = Some(ShutdownReason::Unmount);
+                    break;
+                }
+            }
+
+            match RpcBatch::parse_batch(&mut buffer) {
+                Ok(Some(batch)) => {
+                    let f = partition_senders.lock().await;
+                    let r = f[next_conn].send(batch).await;
+                    next_conn = (next_conn + 1) % f.len();
+                    if let Err(e) = r {
+                        debug!("Error sending RPC batch to connection task {:?}", e);
+                        reason = Some(ShutdownReason::UnexpectedError);
+                        break;
+                    };
+                }
+                Err(RpcFragmentParseError::InvalidSizeTooSmall) => {
+                    drop(read_half);
+                    error!("NFS Client Error: invalid RPC size - size too small");
+                    reason = Some(ShutdownReason::FrameSizeTooSmall);
+                    break;
+                }
+                Err(RpcFragmentParseError::SizeLimitExceeded) => {
+                    drop(read_half);
+                    error!("NFS Client Error: invalid RPC size - size limit exceeded");
+                    reason = Some(ShutdownReason::FrameSizeExceeded);
+                    break;
+                }
+                Ok(None) | Err(RpcFragmentParseError::Incomplete) => (),
+            }
+
+            if buffer.capacity() == 0 {
+                buffer.reserve(BUFFER_SIZE)
+            }
+        }
+        trace!("cli_to_server exiting!");
+        shutdown.exit(reason).await;
+    }
+
+    // Proxy to NFS Client
+    async fn run_writer(
+        mut write_half: OwnedWriteHalf,
+        write_count: Arc<AtomicU64>,
+        mut response_queue: mpsc::Receiver<ConnectionMessage>,
+        shutdown: ShutdownHandle,
+        _shutdown_sender: mpsc::Sender<u8>,
+    ) {
+        trace!("Starting proxy writer");
+
+        let mut reason = None;
+        loop {
+            match response_queue.recv().await {
+                Some(ConnectionMessage::Response(batch)) => {
+                    let mut total_written = 0;
+
+                    for b in &batch.rpcs {
+                        match write_half.write_all(b).await {
+                            Ok(_) => total_written += b.len(),
+                            Err(e) => {
+                                debug!("Error writing to nfs_client. {:?}", e);
+                                reason = Some(ShutdownReason::Unmount);
+                                break;
+                            }
+                        };
+                    }
+
+                    write_count
+                        .fetch_add(total_written as u64, std::sync::atomic::Ordering::AcqRel);
+                }
+                None => {
+                    info!("Exiting server_to_cli");
+                    break;
+                }
+            }
+        }
+        shutdown.exit(reason).await;
+    }
+
+    async fn run_reporter(
+        read_count: Arc<AtomicU64>,
+        write_count: Arc<AtomicU64>,
+        partition_senders: Arc<Mutex<Vec<mpsc::Sender<RpcBatch>>>>,
+        notification_queue: mpsc::Sender<Event<S>>,
+        _shutdown_sender: mpsc::Sender<u8>,
+    ) {
+        trace!("Starting reporter task");
+
+        let mut last = Instant::now();
+        loop {
+            tokio::time::sleep(Duration::from_secs(REPORT_INTERVAL_SECS)).await;
+
+            let num_connections;
+            {
+                let t = partition_senders.lock().await;
+                num_connections = t.len();
+                drop(t);
+            }
+
+            let now = Instant::now();
+            let delta = now - last;
+            last = now;
+            let read = read_count.swap(0, std::sync::atomic::Ordering::AcqRel);
+            let write = write_count.swap(0, std::sync::atomic::Ordering::AcqRel);
+            let result = notification_queue
+                .send(Event::ProxyUpdate(PerformanceStats::new(
+                    num_connections,
+                    read,
+                    write,
+                    delta,
+                )))
+                .await;
+            if result.is_err() {
+                break;
+            }
+        }
+    }
+}
+
+struct ConnectionTask<S> {
+    stream: S,
+    proxy_receiver: mpsc::Receiver<RpcBatch>,
+    proxy_sender: mpsc::Sender<ConnectionMessage>,
+}
+
+impl<S: ProxyStream> ConnectionTask<S> {
+    fn new(
+        stream: S,
+        proxy_receiver: mpsc::Receiver<RpcBatch>,
+        proxy_sender: mpsc::Sender<ConnectionMessage>,
+    ) -> Self {
+        Self {
+            stream,
+            proxy_receiver,
+            proxy_sender,
+        }
+    }
+
+    async fn run(self, shutdown_handle: ShutdownHandle) {
+        let (r, w) = split(self.stream);
+
+        let shutdown = shutdown_handle.clone();
+
+        // This CancellationToken facilitates graceful TLS connection closures by ensuring that
+        // that the ReadHalf is dropped only after the WriteHalf.shutdown() has returned
+        let connection_cancellation_token = CancellationToken::new();
+
+        let writer = Self::run_writer(
+            w,
+            self.proxy_receiver,
+            shutdown_handle.clone(),
+            connection_cancellation_token.clone(),
+        );
+        tokio::spawn(async move {
+            tokio::select! {
+                _ = shutdown.cancellation_token.cancelled() => trace!("Cancelled"),
+                _ = writer => {},
+            }
+        });
+
+        let reader = Self::run_reader(r, self.proxy_sender, shutdown_handle.clone());
+        tokio::spawn(async move {
+            tokio::select! {
+                _ = connection_cancellation_token.cancelled() => trace!("Cancelled"),
+                _ = reader => {},
+            }
+        });
+    }
+
+    // EFS to Proxy
+    async fn run_reader(
+        mut server_read_half: ReadHalf<S>,
+        sender: mpsc::Sender<ConnectionMessage>,
+        shutdown: ShutdownHandle,
+    ) {
+        let reason;
+        let mut buffer = BytesMut::with_capacity(BUFFER_SIZE);
+        loop {
+            match server_read_half.read_buf(&mut buffer).await {
+                Ok(n_read) => {
+                    if n_read == 0 {
+                        reason = Option::Some(ShutdownReason::NeedsRestart);
+                        break;
+                    }
+                }
+                Err(e) => {
+                    debug!("Error reading from server: {:?}", e);
+                    reason = Option::Some(ShutdownReason::NeedsRestart);
+                    break;
+                }
+            };
+
+            match RpcBatch::parse_batch(&mut buffer) {
+                Ok(Some(batch)) => {
+                    if let Err(e) = sender.send(ConnectionMessage::Response(batch)).await {
+                        debug!("Error sending result back: {:?}", e);
+                        reason = Some(ShutdownReason::UnexpectedError);
+                        break;
+                    }
+                }
+                Err(RpcFragmentParseError::InvalidSizeTooSmall) => {
+                    drop(server_read_half);
+                    error!("Server Error: invalid RPC size - size too small");
+                    reason = Some(ShutdownReason::UnexpectedError);
+                    break;
+                }
+                Err(RpcFragmentParseError::SizeLimitExceeded) => {
+                    drop(server_read_half);
+                    error!("Server Error: invalid RPC size - size limit exceeded");
+                    reason = Some(ShutdownReason::UnexpectedError);
+                    break;
+                }
+                Ok(None) | Err(RpcFragmentParseError::Incomplete) => (),
+            }
+
+            if buffer.capacity() == 0 {
+                buffer.reserve(BUFFER_SIZE)
+            }
+        }
+        shutdown.exit(reason).await;
+    }
+
+    // Proxy to EFS
+    async fn run_writer(
+        mut server_write_half: WriteHalf<S>,
+        mut receiver: mpsc::Receiver<RpcBatch>,
+        shutdown: ShutdownHandle,
+        connection_cancellation_token: CancellationToken,
+    ) {
+        let mut reason = Option::None;
+        loop {
+            let Some(batch) = receiver.recv().await else {
+                debug!("sender dropped");
+                break;
+            };
+
+            for b in &batch.rpcs {
+                match server_write_half.write_all(b).await {
+                    Ok(_) => (),
+                    Err(e) => {
+                        debug!("Error writing to server: {:?}", e);
+                        reason = Option::Some(ShutdownReason::NeedsRestart);
+                        break;
+                    }
+                };
+            }
+        }
+
+        tokio::spawn(async move {
+            match server_write_half.shutdown().await {
+                Ok(_) => (),
+                Err(e) => debug!("Failed to gracefully shutdown connection: {}", e),
+            };
+            connection_cancellation_token.cancel();
+        });
+        shutdown.exit(reason).await;
+    }
+}

--- a/src/proxy/src/proxy_identifier.rs
+++ b/src/proxy/src/proxy_identifier.rs
@@ -1,0 +1,54 @@
+use uuid::Uuid;
+
+pub const INITIAL_INCARNATION: i64 = 0;
+
+#[derive(Eq, PartialEq, Clone, Copy, Debug)]
+pub struct ProxyIdentifier {
+    pub uuid: Uuid,
+    pub incarnation: i64,
+}
+
+impl ProxyIdentifier {
+    pub fn new() -> Self {
+        ProxyIdentifier {
+            uuid: Uuid::new_v4(),
+            incarnation: INITIAL_INCARNATION,
+        }
+    }
+
+    pub fn increment(&mut self) {
+        if self.incarnation == i64::MAX {
+            self.incarnation = 0;
+            return;
+        }
+        self.incarnation += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProxyIdentifier;
+    use super::INITIAL_INCARNATION;
+
+    #[test]
+    fn test_increment() {
+        let mut proxy_id = ProxyIdentifier::new();
+        let proxy_id_original = proxy_id.clone();
+        for i in 0..5 {
+            assert_eq!(i, proxy_id.incarnation);
+            proxy_id.increment();
+        }
+        assert_eq!(proxy_id_original.uuid, proxy_id.uuid);
+        assert_eq!(INITIAL_INCARNATION, proxy_id_original.incarnation);
+    }
+
+    #[test]
+    fn test_wrap_around() {
+        let mut proxy_id = ProxyIdentifier::new();
+        let proxy_id_original = proxy_id.clone();
+        proxy_id.incarnation = i64::MAX;
+        proxy_id.increment();
+        assert_eq!(proxy_id_original.uuid, proxy_id.uuid);
+        assert_eq!(INITIAL_INCARNATION, proxy_id.incarnation);
+    }
+}

--- a/src/proxy/src/rpc.rs
+++ b/src/proxy/src/rpc.rs
@@ -1,0 +1,242 @@
+use std::io::Cursor;
+
+use bytes::{Buf, Bytes, BytesMut};
+use tokio::io::AsyncReadExt;
+
+use crate::connections::ProxyStream;
+
+// Each element is an RPC call.
+pub struct RpcBatch {
+    pub rpcs: Vec<Bytes>,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum RpcFragmentParseError {
+    InvalidSizeTooSmall,
+    SizeLimitExceeded,
+    Incomplete,
+}
+
+pub const RPC_LAST_FRAG: u32 = 0x80000000;
+pub const RPC_SIZE_MASK: u32 = 0x7FFFFFFF;
+pub const RPC_HEADER_SIZE: usize = 4;
+
+/* The sunrpc server implementation in linux has a maximum payload of 1MB + 1 page
+ * (see include/linux/sunrpc/svc.h#RPCSVC_MAXPAYLOAD and sv_max_mesg).
+ */
+pub const RPC_MAX_SIZE: usize = 1024 * 1024 + 4 * 1024;
+pub const RPC_MIN_SIZE: usize = 2;
+
+impl RpcBatch {
+    pub fn parse_batch(buffer: &mut BytesMut) -> Result<Option<RpcBatch>, RpcFragmentParseError> {
+        let mut batch = RpcBatch { rpcs: Vec::new() };
+
+        loop {
+            match Self::check_rpc_message(Cursor::new(&buffer[..])) {
+                Ok(len) => {
+                    let rpc_message = buffer.split_to(len);
+                    batch.rpcs.push(rpc_message.freeze());
+                }
+                Err(RpcFragmentParseError::Incomplete) => break,
+                Err(e) => return Err(e),
+            }
+        }
+
+        if batch.rpcs.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(batch))
+        }
+    }
+
+    pub fn check_rpc_message(mut src: Cursor<&[u8]>) -> Result<usize, RpcFragmentParseError> {
+        loop {
+            if src.remaining() < RPC_HEADER_SIZE {
+                return Err(RpcFragmentParseError::Incomplete);
+            }
+
+            let fragment_header = src.get_u32();
+            let fragment_size = (fragment_header & RPC_SIZE_MASK) as usize;
+            let is_last_fragment = (fragment_header & RPC_LAST_FRAG) != 0;
+
+            if fragment_size <= RPC_MIN_SIZE {
+                return Err(RpcFragmentParseError::InvalidSizeTooSmall);
+            }
+
+            if fragment_size >= RPC_MAX_SIZE {
+                return Err(RpcFragmentParseError::SizeLimitExceeded);
+            }
+
+            if src.remaining() < fragment_size {
+                return Err(RpcFragmentParseError::Incomplete);
+            }
+
+            src.advance(fragment_size);
+
+            if is_last_fragment {
+                return Ok(src.position() as usize);
+            }
+        }
+    }
+}
+
+pub async fn read_rpc_bytes(stream: &mut dyn ProxyStream) -> Result<Vec<u8>, tokio::io::Error> {
+    let mut header = [0; RPC_HEADER_SIZE];
+    stream.read_exact(&mut header).await?;
+
+    // NOTE: onc-rpc crate does not support fragmentation out of the box. Add 4 to include the header.
+    let len = (RPC_SIZE_MASK & extract_u32_from_bytes(&header)) + RPC_HEADER_SIZE as u32;
+
+    let mut payload = vec![0; len as usize];
+    payload[0..RPC_HEADER_SIZE].clone_from_slice(&header);
+
+    stream.read_exact(&mut payload[RPC_HEADER_SIZE..]).await?;
+
+    Ok(payload)
+}
+
+fn extract_u32_from_bytes(header: &[u8]) -> u32 {
+    u32::from_be_bytes([header[0], header[1], header[2], header[3]])
+}
+
+#[cfg(test)]
+pub mod test {
+    use crate::rpc::RPC_MAX_SIZE;
+
+    use super::{RpcBatch, RpcFragmentParseError, RPC_HEADER_SIZE, RPC_LAST_FRAG};
+    use bytes::{BufMut, BytesMut};
+    use rand::Rng;
+
+    // Generates message fragments for tests
+    //
+    // This function generates a set of message fragments from random data. The fragments are constructed
+    // in a way that they can be later assembled  into the full long message data
+    // function.
+    //
+    // # Arguments
+    // * `size` - The total size of the message.
+    // * `num_fragments` - The number of fragments to generate.
+    //
+    pub fn generate_msg_fragments(size: usize, num_fragments: usize) -> (bytes::BytesMut, Vec<u8>) {
+        let mut rng = rand::thread_rng();
+        let data: Vec<u8> = (0..size).map(|_| rng.gen()).collect();
+
+        let fragment_data_size = data.len() / num_fragments;
+
+        let mut data_buffer = bytes::BytesMut::new();
+        for i in 0..num_fragments {
+            let start_idx = i * fragment_data_size;
+            let end_idx = std::cmp::min(size, start_idx + fragment_data_size);
+            let fragment_data = &data[start_idx..end_idx];
+
+            let mut header = (end_idx - start_idx) as u32;
+            if end_idx == size {
+                header |= 1 << 31;
+            }
+
+            data_buffer.extend_from_slice(&header.to_be_bytes());
+            data_buffer.extend_from_slice(fragment_data);
+        }
+        assert_eq!(data_buffer.len(), (num_fragments * 4) + data.len());
+
+        (data_buffer, data)
+    }
+
+    #[test]
+    fn multiple_messages() {
+        let mut b = BytesMut::with_capacity(8);
+        b.put_u32(RPC_LAST_FRAG | 4);
+        b.put_u32(42);
+        b.put_u32(RPC_LAST_FRAG | 4);
+
+        let batch = RpcBatch::parse_batch(&mut b);
+        let batch = batch.unwrap().unwrap();
+        assert_eq!(batch.rpcs[0].len(), 8);
+        assert_eq!(batch.rpcs.len(), 1);
+
+        b.put_u32(43);
+        let batch = RpcBatch::parse_batch(&mut b);
+        let batch = batch.unwrap().unwrap();
+        assert_eq!(batch.rpcs[0].len(), 8);
+        assert_eq!(batch.rpcs.len(), 1);
+
+        let batch = RpcBatch::parse_batch(&mut b);
+        assert!(matches!(batch, Ok(None)));
+    }
+
+    #[test]
+    fn test_invalid_rpc_small_fragment() {
+        let num_fragments = 1;
+        let (mut input_buffer, _) = generate_msg_fragments(1, num_fragments);
+        let result = RpcBatch::parse_batch(&mut input_buffer);
+        assert!(matches!(
+            result,
+            Err(RpcFragmentParseError::InvalidSizeTooSmall)
+        ));
+    }
+
+    #[test]
+    fn test_invalid_rpc_big_fragment() {
+        let num_fragments = 1;
+        let (mut input_buffer, _) = generate_msg_fragments(RPC_MAX_SIZE + 1, num_fragments);
+        let result = RpcBatch::parse_batch(&mut input_buffer);
+        assert!(matches!(
+            result,
+            Err(RpcFragmentParseError::SizeLimitExceeded)
+        ));
+    }
+
+    #[test]
+    fn test_parse_batch_single_message() {
+        // Create an input buffer with multiple RPC fragments
+        let num_fragments = 3;
+        let message_size = 12;
+        let (mut input_buffer, _) = generate_msg_fragments(message_size, num_fragments);
+        let mut rpc_batch = RpcBatch::parse_batch(&mut input_buffer)
+            .expect("parse batch failed")
+            .expect("no rpc messages found");
+
+        assert_eq!(1, rpc_batch.rpcs.len());
+        let rpc_message = rpc_batch.rpcs.pop().expect("No RPC messages");
+
+        let expected_message_size = num_fragments * RPC_HEADER_SIZE + message_size;
+        assert_eq!(expected_message_size, rpc_message.len());
+    }
+
+    #[test]
+    fn test_parse_batch_multiple_message() {
+        // Create an input buffer with multiple RPC messages
+        let num_fragments_1 = 3;
+        let message_size_1 = 12;
+        let (mut input_buffer, _) = generate_msg_fragments(message_size_1, num_fragments_1);
+
+        let num_fragments_2 = 6;
+        let message_size_2 = 24;
+        let (input_buffer_2, _) = generate_msg_fragments(message_size_2, num_fragments_2);
+
+        let num_fragments_3 = 1;
+        let message_size_3 = 50;
+        let (input_buffer_3, _) = generate_msg_fragments(message_size_3, num_fragments_3);
+
+        input_buffer.extend_from_slice(&input_buffer_2);
+        input_buffer.extend_from_slice(&input_buffer_3);
+
+        let mut rpc_batch = RpcBatch::parse_batch(&mut input_buffer)
+            .expect("parse batch failed")
+            .expect("no rpc messages found");
+
+        assert_eq!(3, rpc_batch.rpcs.len());
+
+        let rpc_message_3 = rpc_batch.rpcs.pop().expect("No RPC messages");
+        let expected_message_size_3 = num_fragments_3 * RPC_HEADER_SIZE + message_size_3;
+        assert_eq!(expected_message_size_3, rpc_message_3.len());
+
+        let rpc_message_2 = rpc_batch.rpcs.pop().expect("No RPC messages");
+        let expected_message_size_2 = num_fragments_2 * RPC_HEADER_SIZE + message_size_2;
+        assert_eq!(expected_message_size_2, rpc_message_2.len());
+
+        let rpc_message_1 = rpc_batch.rpcs.pop().expect("No RPC messages");
+        let expected_message_size_1 = num_fragments_1 * RPC_HEADER_SIZE + message_size_1;
+        assert_eq!(expected_message_size_1, rpc_message_1.len());
+    }
+}

--- a/src/proxy/src/shutdown.rs
+++ b/src/proxy/src/shutdown.rs
@@ -1,0 +1,85 @@
+use log::debug;
+use tokio::sync::mpsc::{self, Receiver, Sender};
+use tokio_util::sync::CancellationToken;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum ShutdownReason {
+    NeedsRestart,
+    UnexpectedError,
+    Unmount,
+    FrameSizeExceeded,
+    FrameSizeTooSmall,
+}
+
+#[derive(Clone)]
+pub struct ShutdownHandle {
+    pub cancellation_token: CancellationToken,
+    notifier: Sender<ShutdownReason>,
+}
+
+impl ShutdownHandle {
+    pub fn new(cancellation_token: CancellationToken) -> (Self, Receiver<ShutdownReason>) {
+        let (notifier, r) = mpsc::channel(1024);
+        let h = Self {
+            cancellation_token,
+            notifier,
+        };
+        (h, r)
+    }
+
+    pub async fn exit(self, reason: Option<ShutdownReason>) {
+        debug!("Exiting: {:?}", reason);
+        self.cancellation_token.cancel();
+        if let Some(reason) = reason {
+            let _ = self.notifier.send(reason).await;
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use log::info;
+    use std::time::Duration;
+
+    use tokio::sync::mpsc;
+    use tokio_util::sync::CancellationToken;
+
+    use super::ShutdownHandle;
+
+    #[tokio::test]
+    async fn test() {
+        let (t, mut r) = mpsc::channel(1);
+        let token = CancellationToken::new();
+
+        let s1 = ShutdownHandle {
+            cancellation_token: token.clone(),
+            notifier: t.clone(),
+        };
+        let s2 = ShutdownHandle {
+            cancellation_token: token.clone(),
+            notifier: t.clone(),
+        };
+
+        tokio::spawn(run_task(s1, false));
+        tokio::spawn(run_task(s2, true));
+        drop(t);
+
+        let _ = r.recv().await;
+        info!("Done");
+    }
+
+    async fn run_task(shutdown: ShutdownHandle, to_cancel: bool) {
+        let f = async {
+            if to_cancel {
+                shutdown.cancellation_token.clone().cancel()
+            } else {
+                tokio::time::sleep(Duration::from_secs(10)).await;
+            }
+        };
+        tokio::select! {
+            _ = shutdown.cancellation_token.cancelled() => {},
+            _ = f => {}
+        }
+        info!("Task exiting");
+    }
+}

--- a/src/proxy/src/status_reporter.rs
+++ b/src/proxy/src/status_reporter.rs
@@ -1,0 +1,110 @@
+use crate::controller::ConnectionSearchState;
+use crate::efs_rpc::PartitionId;
+use crate::{proxy::PerformanceStats, proxy_identifier::ProxyIdentifier};
+use anyhow::{Error, Result};
+use tokio::sync::mpsc::{self, Receiver, Sender};
+use tokio::time::Instant;
+
+pub struct Report {
+    pub proxy_id: ProxyIdentifier,
+    pub partition_id: Option<PartitionId>,
+    pub connection_state: ConnectionSearchState,
+    pub num_connections: usize,
+    pub last_proxy_update: Option<(Instant, PerformanceStats)>,
+    pub scale_up_attempt_count: u64,
+    pub restart_count: u64,
+}
+
+type Request = ();
+type Response = Report;
+
+pub struct StatusReporter {
+    pub sender: Sender<Response>,
+    pub receiver: Receiver<Request>,
+}
+
+impl StatusReporter {
+    pub async fn await_report_request(&mut self) -> Result<()> {
+        self.receiver
+            .recv()
+            .await
+            .ok_or_else(|| Error::msg("Request channel closed"))?;
+        Ok(())
+    }
+
+    // Note: This should only be called when a message is received by the receiver.
+    pub async fn publish_status(&mut self, report: Report) {
+        match self.sender.send(report).await {
+            Ok(_) => (),
+            Err(e) => panic!("StatusReporter could not send report {}", e),
+        }
+    }
+}
+
+pub struct StatusRequester {
+    _sender: Sender<Request>,
+    _receiver: Receiver<Response>,
+}
+
+impl StatusRequester {
+    pub async fn _request_status(&mut self) -> Result<Report> {
+        self._sender.send(()).await?;
+        self._receiver
+            .recv()
+            .await
+            .ok_or_else(|| Error::msg("Response channel closed"))
+    }
+}
+
+pub fn create_status_channel() -> (StatusRequester, StatusReporter) {
+    let (call_sender, call_receiver) = mpsc::channel::<Request>(1);
+    let (reply_sender, reply_receiver) = mpsc::channel::<Response>(1);
+
+    let status_requester = StatusRequester {
+        _sender: call_sender,
+        _receiver: reply_receiver,
+    };
+
+    let status_reporter = StatusReporter {
+        sender: reply_sender,
+        receiver: call_receiver,
+    };
+
+    (status_requester, status_reporter)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_basic() -> Result<()> {
+        let proxy_id = ProxyIdentifier::new();
+
+        let (mut status_requester, mut status_reporter) = create_status_channel();
+        tokio::spawn(async move {
+            status_reporter
+                .await_report_request()
+                .await
+                .expect("Request channel closed");
+            let report = Report {
+                proxy_id: proxy_id.clone(),
+                partition_id: None,
+                connection_state: ConnectionSearchState::Idle,
+                num_connections: 1,
+                last_proxy_update: None,
+                scale_up_attempt_count: 0,
+                restart_count: 0,
+            };
+            status_reporter.publish_status(report).await
+        });
+
+        let r = status_requester._request_status().await?;
+        assert_eq!(proxy_id, r.proxy_id);
+        assert!(matches!(r.partition_id, None));
+        assert_eq!(r.connection_state, ConnectionSearchState::Idle);
+        assert!(matches!(r.last_proxy_update, None));
+        assert_eq!(1, r.num_connections);
+        Ok(())
+    }
+}

--- a/src/proxy/src/tls.rs
+++ b/src/proxy/src/tls.rs
@@ -1,0 +1,230 @@
+use anyhow::{Context, Result};
+use log::*;
+use nix::NixPath;
+use s2n_tls::enums::ClientAuthType::Optional;
+use s2n_tls::security::Policy;
+use s2n_tls::{config::Config, security::DEFAULT_TLS13};
+use s2n_tls_tokio::TlsConnector;
+use s2n_tls_tokio::TlsStream;
+use std::path::Path;
+use tokio::net::TcpStream;
+
+use crate::error::ConnectError;
+
+pub const FIPS_COMPLIANT_POLICY_VERSION: &str = "20230317";
+pub struct InsecureAcceptAllCertificatesHandler;
+impl s2n_tls::callbacks::VerifyHostNameCallback for InsecureAcceptAllCertificatesHandler {
+    fn verify_host_name(&self, _host_name: &str) -> bool {
+        true
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TlsConfig {
+    pub fips_enabled: bool,
+
+    /// Contents of the certificate authority file. E.g. /etc/amazon/efs/efs-utils.crt
+    pub ca_file_contents: Vec<u8>,
+
+    /// The client-side certificate and public key
+    pub client_cert: Vec<u8>,
+
+    /// The client private key
+    pub client_private_key: Vec<u8>,
+
+    /// The remote address to establish the TLS connection with
+    pub remote_addr: String,
+
+    /// The hostname that is expected to be on the remote server's TLS certificate
+    pub server_domain: String,
+}
+
+// s2n-tls errors if there are comments in the certificate files. This function removes comments if
+// they are present.
+async fn read_file_with_comments_removed(path: &Path) -> Result<Vec<u8>> {
+    let file = tokio::fs::File::open(path).await?;
+    let reader = tokio::io::BufReader::new(file);
+    let mut lines = tokio::io::AsyncBufReadExt::lines(reader);
+
+    let mut output = Vec::new();
+    while let Ok(Some(line)) = lines.next_line().await {
+        if !line.starts_with("# ") {
+            if !output.is_empty() {
+                output.push(b'\n');
+            }
+
+            output.extend_from_slice(line.as_bytes());
+        }
+    }
+    Ok(output)
+}
+
+impl TlsConfig {
+    /// Create an instance of TlsConfig.
+    ///
+    /// This will return an error if the files could not be read or the remote address could not be resolved.
+    ///
+    /// # Arguments
+    /// * `ca_file` - File path of the certificate authority file. E.g. /etc/amazon/efs/efs-utils.crt
+    /// * `client_cert_pem_file` - File path of the file that contains the client-side certificate and public key
+    /// * `client_private_key_pem_file` - File path of the file that contains the client private key
+    /// * `remote_addr` - The remote address to establish the TLS connection with
+    /// * `server_domain` - The hostname that is expected to be on the certificate that the remote server presents
+    ///
+    pub async fn new(
+        fips_enabled: bool,
+        ca_file: &Path,
+        client_cert_pem_file: &Path,
+        client_private_key_pem_file: &Path,
+        remote_addr: &str,
+        server_domain: &str,
+    ) -> Result<Self> {
+        let mut ca_file_contents: Vec<u8> = Vec::new();
+        if !ca_file.is_empty() {
+            ca_file_contents = read_file_with_comments_removed(ca_file).await.context(
+                String::from("Error in TlsConfig::new. Unable to the CA File. Make sure it does not have any comments (lines that start with #)."))?;
+        }
+        let client_cert = read_file_with_comments_removed(client_cert_pem_file)
+            .await
+            .context(String::from(
+                "Error in TlsConfig::new. Unable to read the client certificate file.",
+            ))?;
+        let client_private_key = read_file_with_comments_removed(client_private_key_pem_file)
+            .await
+            .context(String::from(
+                "Error in TlsConfig::new. Unable to read private key file.",
+            ))?;
+        let server_domain = server_domain.to_string();
+        let remote_addr = remote_addr.to_string();
+
+        Ok(TlsConfig {
+            fips_enabled,
+            ca_file_contents,
+            client_cert,
+            client_private_key,
+            remote_addr,
+            server_domain,
+        })
+    }
+
+    #[cfg(test)]
+    pub async fn new_from_config(config: &crate::ProxyConfig) -> Result<TlsConfig> {
+        let efs_config = &config.nested_config;
+
+        let ca_file = Path::new(&efs_config.ca_file);
+        let ca_cert_pem = Path::new(&efs_config.client_cert_pem_file);
+        let private_key_pem = Path::new(&efs_config.client_private_key_pem_file);
+        if !ca_file.exists() || !ca_cert_pem.exists() || !private_key_pem.exists() {
+            let error_msg = "One or more required files for TLS config are missing";
+            return Err(anyhow::Error::msg(error_msg));
+        }
+        TlsConfig::new(
+            config.fips,
+            &ca_file,
+            &ca_cert_pem,
+            &private_key_pem,
+            efs_config.mount_target_addr.as_str(),
+            efs_config.expected_server_hostname_tls.as_str(),
+        )
+        .await
+    }
+}
+
+/// Establishes a TLS stream using the configuration and remote address specified in tls_config
+pub async fn establish_tls_stream(
+    tls_config: TlsConfig,
+) -> Result<TlsStream<TcpStream>, ConnectError> {
+    let config = create_config_builder(&tls_config).build()?;
+
+    let tls_connector = TlsConnector::new(config);
+
+    let tcp_stream = TcpStream::connect(tls_config.remote_addr).await?;
+
+    let tls_stream = tls_connector
+        .connect(&tls_config.server_domain, tcp_stream)
+        .await?;
+
+    debug!("{:#?}", tls_stream);
+    Ok(tls_stream)
+}
+
+fn create_config_builder(tls_config: &TlsConfig) -> s2n_tls::config::Builder {
+    let mut config = Config::builder();
+
+    let policy = if tls_config.fips_enabled {
+        Policy::from_version(FIPS_COMPLIANT_POLICY_VERSION).expect("Invalid policy")
+    } else {
+        DEFAULT_TLS13
+    };
+    config
+        .set_security_policy(&policy)
+        .expect("Error in create_tls_connector. Failed to set security policy.");
+    config
+        .set_client_auth_type(Optional)
+        .expect("Error in create_tls_connector. Failed to set client auth type.");
+    config
+        .load_pem(&tls_config.client_cert, &tls_config.client_private_key)
+        .expect(
+            "Error in create_tls_connector. Failed to load the client certificate and private key.",
+        );
+
+    // If the customer is using the verify=0 mount option, we want to disable cert verification.
+    if !tls_config.ca_file_contents.is_empty() {
+        config
+            .trust_pem(&tls_config.ca_file_contents)
+            .expect("Error in create_tls_connector. Failed to add the CA file to the trust store.");
+    } else {
+        unsafe {
+            config
+                .disable_x509_verification()
+                .expect("Error disabling x509 verification");
+        };
+    }
+
+    // If stunnel_check_cert_hostname = false in efs-utils config, then we don't verify the hostname
+    if tls_config.server_domain.is_empty() {
+        config
+            .set_verify_host_callback(InsecureAcceptAllCertificatesHandler)
+            .expect("Unable to disable host name verification");
+    }
+
+    config
+}
+
+#[cfg(test)]
+pub mod tests {
+
+    use crate::config_parser::tests::get_test_config;
+
+    use super::*;
+
+    pub async fn get_client_config() -> Result<Config> {
+        let tls_config = TlsConfig::new_from_config(&get_test_config()).await?;
+        let builder = create_config_builder(&tls_config);
+
+        let config = builder.build()?;
+        Ok(config)
+    }
+
+    pub async fn get_server_config() -> Result<Config> {
+        let tls_config = TlsConfig::new_from_config(&get_test_config()).await?;
+        let mut builder = create_config_builder(&tls_config);
+
+        // Accept all client certificates
+        builder.set_verify_host_callback(InsecureAcceptAllCertificatesHandler {})?;
+
+        let config = builder.build()?;
+        Ok(config)
+    }
+
+    #[tokio::test]
+    async fn test_remove_comments() {
+        let comment_file = Path::new("tests/certs/cert_with_comments.pem");
+        let decommented_output = read_file_with_comments_removed(comment_file).await;
+
+        let expected = tokio::fs::read(&Path::new("tests/certs/cert.pem"))
+            .await
+            .expect("Could not read certificate file");
+        assert_eq!(expected.len(), decommented_output.unwrap().len());
+    }
+}

--- a/test/mount_efs_test/test_add_stunnel_ca_options.py
+++ b/test/mount_efs_test/test_add_stunnel_ca_options.py
@@ -41,7 +41,7 @@ def test_use_existing_cafile(tmpdir):
     options = {"cafile": str(_create_temp_file(tmpdir))}
     efs_config = {}
 
-    mount_efs.add_stunnel_ca_options(efs_config, _get_config(), options, DEFAULT_REGION)
+    mount_efs.add_tunnel_ca_options(efs_config, _get_config(), options, DEFAULT_REGION)
 
     assert options["cafile"] == efs_config.get("CAfile")
     assert "CApath" not in efs_config
@@ -52,7 +52,7 @@ def test_use_missing_cafile(capsys):
     efs_config = {}
 
     with pytest.raises(SystemExit) as ex:
-        mount_efs.add_stunnel_ca_options(
+        mount_efs.add_tunnel_ca_options(
             efs_config, _get_config(), options, DEFAULT_REGION
         )
 
@@ -68,7 +68,7 @@ def test_stunnel_cafile_configuration_in_option(mocker):
 
     mocker.patch("os.path.exists", return_value=True)
 
-    mount_efs.add_stunnel_ca_options(efs_config, _get_config(), options, DEFAULT_REGION)
+    mount_efs.add_tunnel_ca_options(efs_config, _get_config(), options, DEFAULT_REGION)
 
     assert CAFILE == efs_config.get("CAfile")
 
@@ -82,7 +82,7 @@ def test_stunnel_cafile_configuration_in_config(mocker):
 
     mocker.patch("os.path.exists", return_value=True)
 
-    mount_efs.add_stunnel_ca_options(efs_config, config, options, DEFAULT_REGION)
+    mount_efs.add_tunnel_ca_options(efs_config, config, options, DEFAULT_REGION)
 
     assert CAFILE == efs_config.get("CAfile")
 
@@ -93,7 +93,7 @@ def test_stunnel_cafile_not_configured(mocker):
 
     mocker.patch("os.path.exists", return_value=True)
 
-    mount_efs.add_stunnel_ca_options(efs_config, _get_config(), options, DEFAULT_REGION)
+    mount_efs.add_tunnel_ca_options(efs_config, _get_config(), options, DEFAULT_REGION)
 
     assert mount_efs.DEFAULT_STUNNEL_CAFILE == efs_config.get("CAfile")
 
@@ -110,6 +110,6 @@ def test_stunnel_cafile_configured_in_mount_region_section(mocker):
 
     mocker.patch("os.path.exists", return_value=True)
 
-    mount_efs.add_stunnel_ca_options(efs_config, config, options, ISOLATED_REGION)
+    mount_efs.add_tunnel_ca_options(efs_config, config, options, ISOLATED_REGION)
 
     assert ISOLATED_REGION_STUNNEL_CAFILE == efs_config.get("CAfile")

--- a/test/mount_efs_test/test_bootstrap_proxy.py
+++ b/test/mount_efs_test/test_bootstrap_proxy.py
@@ -40,14 +40,16 @@ def setup_mocks(mocker):
         return_value=(DNS_NAME, None),
     )
     mocker.patch("mount_efs.get_target_region", return_value=REGION)
-    mocker.patch("mount_efs.write_tls_tunnel_state_file", return_value="~mocktempfile")
+    mocker.patch("mount_efs.write_tunnel_state_file", return_value="~mocktempfile")
     mocker.patch("mount_efs.create_certificate")
     mocker.patch("os.rename")
     mocker.patch("os.kill")
     mocker.patch(
-        "mount_efs.update_tls_tunnel_temp_state_file_with_tunnel_pid",
+        "mount_efs.update_tunnel_temp_state_file_with_tunnel_pid",
         return_value="~mocktempfile",
     )
+
+    mocker.patch("mount_efs.get_efs_proxy_log_level", return_value="info")
 
     process_mock = MagicMock()
     process_mock.communicate.return_value = (
@@ -74,10 +76,10 @@ def setup_mocks_without_popen(mocker):
         "mount_efs.get_dns_name_and_fallback_mount_target_ip_address",
         return_value=(DNS_NAME, None),
     )
-    mocker.patch("mount_efs.write_tls_tunnel_state_file", return_value="~mocktempfile")
+    mocker.patch("mount_efs.write_tunnel_state_file", return_value="~mocktempfile")
     mocker.patch("os.kill")
     mocker.patch(
-        "mount_efs.update_tls_tunnel_temp_state_file_with_tunnel_pid",
+        "mount_efs.update_tunnel_temp_state_file_with_tunnel_pid",
         return_value="~mocktempfile",
     )
 
@@ -87,12 +89,12 @@ def setup_mocks_without_popen(mocker):
     return write_config_mock
 
 
-def test_bootstrap_tls_state_file_dir_exists(mocker, tmpdir):
+def test_bootstrap_proxy_state_file_dir_exists(mocker, tmpdir):
     popen_mock, _ = setup_mocks(mocker)
     state_file_dir = str(tmpdir)
-
-    mocker.patch("mount_efs._stunnel_bin", return_value="/usr/bin/stunnel")
-    with mount_efs.bootstrap_tls(
+    mocker.patch("mount_efs.is_ocsp_enabled", return_value=False)
+    mocker.patch("mount_efs._efs_proxy_bin", return_value="/usr/bin/efs-proxy")
+    with mount_efs.bootstrap_proxy(
         MOCK_CONFIG, INIT_SYSTEM, DNS_NAME, FS_ID, MOUNT_POINT, {}, state_file_dir
     ):
         pass
@@ -100,11 +102,11 @@ def test_bootstrap_tls_state_file_dir_exists(mocker, tmpdir):
     args, _ = popen_mock.call_args
     args = args[0]
 
-    assert "/usr/bin/stunnel" in args
+    assert "/usr/bin/efs-proxy" in args
     assert EXPECTED_STUNNEL_CONFIG_FILE in args
 
 
-def test_bootstrap_tls_state_file_nonexistent_dir(mocker, tmpdir):
+def test_bootstrap_proxy_state_file_nonexistent_dir(mocker, tmpdir):
     popen_mock, _ = setup_mocks(mocker)
     state_file_dir = str(tmpdir.join(tempfile.mkdtemp()[1]))
 
@@ -122,9 +124,10 @@ def test_bootstrap_tls_state_file_nonexistent_dir(mocker, tmpdir):
 
     assert not os.path.exists(state_file_dir)
 
-    mocker.patch("mount_efs._stunnel_bin", return_value="/usr/bin/stunnel")
+    mocker.patch("mount_efs.is_ocsp_enabled", return_value=False)
+    mocker.patch("mount_efs._efs_proxy_bin", return_value="/usr/bin/efs-proxy")
     mocker.patch("mount_efs.find_existing_mount_using_tls_port", return_value=None)
-    with mount_efs.bootstrap_tls(
+    with mount_efs.bootstrap_proxy(
         MOCK_CONFIG, INIT_SYSTEM, DNS_NAME, FS_ID, MOUNT_POINT, {}, state_file_dir
     ):
         pass
@@ -132,7 +135,52 @@ def test_bootstrap_tls_state_file_nonexistent_dir(mocker, tmpdir):
     assert os.path.exists(state_file_dir)
 
 
-def test_bootstrap_tls_cert_created(mocker, tmpdir):
+def test_bootstrap_proxy_cert_created_tls_mount(mocker, tmpdir):
+    setup_mocks_without_popen(mocker)
+    mocker.patch("mount_efs.get_mount_specific_filename", return_value=DNS_NAME)
+    mocker.patch("mount_efs.get_target_region", return_value=REGION)
+    state_file_dir = str(tmpdir)
+    tls_dict = mount_efs.tls_paths_dictionary(DNS_NAME + "+", state_file_dir)
+    mocker.patch("mount_efs.is_ocsp_enabled", return_value=False)
+    pk_path = os.path.join(str(tmpdir), "privateKey.pem")
+    mocker.patch("mount_efs.get_private_key_path", return_value=pk_path)
+
+    def config_get_side_effect(section, field):
+        if section == mount_efs.CONFIG_SECTION and field == "state_file_dir_mode":
+            return "0755"
+        elif section == mount_efs.CONFIG_SECTION and field == "dns_name_format":
+            return "{fs_id}.efs.{region}.amazonaws.com"
+        elif section == mount_efs.CONFIG_SECTION and field == "logging_level":
+            return "info"
+        elif section == mount_efs.CLIENT_INFO_SECTION and field == "source":
+            return CLIENT_SOURCE
+        else:
+            raise ValueError("Unexpected arguments")
+
+    MOCK_CONFIG.get.side_effect = config_get_side_effect
+
+    mocker.patch("mount_efs._efs_proxy_bin", return_value="/usr/bin/efs-proxy")
+    try:
+        with mount_efs.bootstrap_proxy(
+            MOCK_CONFIG,
+            INIT_SYSTEM,
+            DNS_NAME,
+            FS_ID,
+            MOUNT_POINT,
+            {"accesspoint": AP_ID, "tls": None},
+            state_file_dir,
+        ):
+            pass
+    except OSError as e:
+        assert "[Errno 2] No such file or directory" in str(e)
+
+    assert os.path.exists(os.path.join(tls_dict["mount_dir"], "certificate.pem"))
+    assert os.path.exists(os.path.join(tls_dict["mount_dir"], "request.csr"))
+    assert os.path.exists(os.path.join(tls_dict["mount_dir"], "config.conf"))
+    assert os.path.exists(pk_path)
+
+
+def test_bootstrap_proxy_cert_not_created_non_tls_mount(mocker, tmpdir):
     setup_mocks_without_popen(mocker)
     mocker.patch("mount_efs.get_mount_specific_filename", return_value=DNS_NAME)
     mocker.patch("mount_efs.get_target_region", return_value=REGION)
@@ -147,6 +195,8 @@ def test_bootstrap_tls_cert_created(mocker, tmpdir):
             return "0755"
         elif section == mount_efs.CONFIG_SECTION and field == "dns_name_format":
             return "{fs_id}.efs.{region}.amazonaws.com"
+        elif section == mount_efs.CONFIG_SECTION and field == "logging_level":
+            return "info"
         elif section == mount_efs.CLIENT_INFO_SECTION and field == "source":
             return CLIENT_SOURCE
         else:
@@ -154,9 +204,10 @@ def test_bootstrap_tls_cert_created(mocker, tmpdir):
 
     MOCK_CONFIG.get.side_effect = config_get_side_effect
 
-    mocker.patch("mount_efs._stunnel_bin", return_value="/usr/bin/stunnel")
+    mocker.patch("mount_efs.is_ocsp_enabled", return_value=False)
+    mocker.patch("mount_efs._efs_proxy_bin", return_value="/usr/bin/efs-proxy")
     try:
-        with mount_efs.bootstrap_tls(
+        with mount_efs.bootstrap_proxy(
             MOCK_CONFIG,
             INIT_SYSTEM,
             DNS_NAME,
@@ -169,13 +220,13 @@ def test_bootstrap_tls_cert_created(mocker, tmpdir):
     except OSError as e:
         assert "[Errno 2] No such file or directory" in str(e)
 
-    assert os.path.exists(os.path.join(tls_dict["mount_dir"], "certificate.pem"))
-    assert os.path.exists(os.path.join(tls_dict["mount_dir"], "request.csr"))
-    assert os.path.exists(os.path.join(tls_dict["mount_dir"], "config.conf"))
-    assert os.path.exists(pk_path)
+    assert not os.path.exists(os.path.join(tls_dict["mount_dir"], "certificate.pem"))
+    assert not os.path.exists(os.path.join(tls_dict["mount_dir"], "request.csr"))
+    assert not os.path.exists(os.path.join(tls_dict["mount_dir"], "config.conf"))
+    assert not os.path.exists(pk_path)
 
 
-def test_bootstrap_tls_non_default_port(mocker, tmpdir):
+def test_bootstrap_proxy_non_default_port(mocker, tmpdir):
     popen_mock, write_config_mock = setup_mocks(mocker)
     mocker.patch("os.rename")
     state_file_dir = str(tmpdir)
@@ -185,9 +236,9 @@ def test_bootstrap_tls_non_default_port(mocker, tmpdir):
     tls_port_sock_mock.getsockname.return_value = ("local_host", tls_port)
     tls_port_sock_mock.close.side_effect = None
     mocker.patch("socket.socket", return_value=tls_port_sock_mock)
-
-    mocker.patch("mount_efs._stunnel_bin", return_value="/usr/bin/stunnel")
-    with mount_efs.bootstrap_tls(
+    mocker.patch("mount_efs.is_ocsp_enabled", return_value=False)
+    mocker.patch("mount_efs._efs_proxy_bin", return_value="/usr/bin/efs-proxy")
+    with mount_efs.bootstrap_proxy(
         MOCK_CONFIG,
         INIT_SYSTEM,
         DNS_NAME,
@@ -202,29 +253,55 @@ def test_bootstrap_tls_non_default_port(mocker, tmpdir):
     popen_args = popen_args[0]
     write_config_args, _ = write_config_mock.call_args
 
-    assert "/usr/bin/stunnel" in popen_args
+    assert "/usr/bin/efs-proxy" in popen_args
     assert EXPECTED_STUNNEL_CONFIG_FILE in popen_args
     assert tls_port == write_config_args[4]  # positional argument for tls_port
-    # Ensure tls port socket is closed in bootstrap_tls
+    # Ensure tls port socket is closed in bootstrap_proxy
     # The number is two here, the first one is the actual socket when choosing tls port, the second one is a socket to
     # verify tls port can be connected after establishing TLS stunnel. They share the same mock.
     assert 2 == tls_port_sock_mock.close.call_count
 
 
-def test_bootstrap_tls_non_default_verify_level(mocker, tmpdir):
+def test_bootstrap_proxy_non_tls_verify_ignored(mocker, tmpdir):
     popen_mock, write_config_mock = setup_mocks(mocker)
     state_file_dir = str(tmpdir)
-
-    verify = 0
-    mocker.patch("mount_efs._stunnel_bin", return_value="/usr/bin/stunnel")
-    with mount_efs.bootstrap_tls(
+    mocker.patch("mount_efs.is_ocsp_enabled", return_value=False)
+    mocker.patch("mount_efs._efs_proxy_bin", return_value="/usr/bin/efs-proxy")
+    with mount_efs.bootstrap_proxy(
         MOCK_CONFIG,
         INIT_SYSTEM,
         DNS_NAME,
         FS_ID,
         MOUNT_POINT,
-        {"verify": verify},
+        {},
         state_file_dir,
+    ):
+        pass
+
+    popen_args, _ = popen_mock.call_args
+    popen_args = popen_args[0]
+    write_config_args, _ = write_config_mock.call_args
+
+    assert "/usr/bin/efs-proxy" in popen_args
+    assert EXPECTED_STUNNEL_CONFIG_FILE in popen_args
+    assert None == write_config_args[6]  # positional argument for verify_level
+
+
+def test_bootstrap_proxy_non_default_verify_level_stunnel(mocker, tmpdir):
+    popen_mock, write_config_mock = setup_mocks(mocker)
+    state_file_dir = str(tmpdir)
+    mocker.patch("mount_efs.is_ocsp_enabled", return_value=False)
+    verify = 0
+    mocker.patch("mount_efs._stunnel_bin", return_value="/usr/bin/stunnel")
+    with mount_efs.bootstrap_proxy(
+        MOCK_CONFIG,
+        INIT_SYSTEM,
+        DNS_NAME,
+        FS_ID,
+        MOUNT_POINT,
+        {"verify": verify, "tls": None},
+        state_file_dir,
+        efs_proxy_enabled=False,
     ):
         pass
 
@@ -237,12 +314,11 @@ def test_bootstrap_tls_non_default_verify_level(mocker, tmpdir):
     assert 0 == write_config_args[6]  # positional argument for verify_level
 
 
-def test_bootstrap_tls_ocsp_option(mocker, tmpdir):
+def test_bootstrap_proxy_ocsp_option(mocker, tmpdir):
     popen_mock, write_config_mock = setup_mocks(mocker)
     state_file_dir = str(tmpdir)
-
     mocker.patch("mount_efs._stunnel_bin", return_value="/usr/bin/stunnel")
-    with mount_efs.bootstrap_tls(
+    with mount_efs.bootstrap_proxy(
         MOCK_CONFIG,
         INIT_SYSTEM,
         DNS_NAME,
@@ -250,6 +326,7 @@ def test_bootstrap_tls_ocsp_option(mocker, tmpdir):
         MOUNT_POINT,
         {"ocsp": None},
         state_file_dir,
+        efs_proxy_enabled=False,
     ):
         pass
 
@@ -263,12 +340,11 @@ def test_bootstrap_tls_ocsp_option(mocker, tmpdir):
     assert write_config_args[7] is True
 
 
-def test_bootstrap_tls_noocsp_option(mocker, tmpdir):
+def test_bootstrap_proxy_noocsp_option(mocker, tmpdir):
     popen_mock, write_config_mock = setup_mocks(mocker)
     state_file_dir = str(tmpdir)
-
     mocker.patch("mount_efs._stunnel_bin", return_value="/usr/bin/stunnel")
-    with mount_efs.bootstrap_tls(
+    with mount_efs.bootstrap_proxy(
         MOCK_CONFIG,
         INIT_SYSTEM,
         DNS_NAME,
@@ -276,6 +352,7 @@ def test_bootstrap_tls_noocsp_option(mocker, tmpdir):
         MOUNT_POINT,
         {"noocsp": None},
         state_file_dir,
+        efs_proxy_enabled=False,
     ):
         pass
 
@@ -287,3 +364,114 @@ def test_bootstrap_tls_noocsp_option(mocker, tmpdir):
     assert EXPECTED_STUNNEL_CONFIG_FILE in popen_args
     # positional argument for ocsp_override
     assert write_config_args[7] is False
+
+
+def test_bootstrap_proxy_efs_proxy_enabled_tls(mocker, tmpdir):
+    popen_mock, _ = setup_mocks(mocker)
+    mocker.patch("os.rename")
+    state_file_dir = str(tmpdir)
+    mocker.patch("mount_efs.is_ocsp_enabled", return_value=False)
+    mocker.patch("mount_efs._efs_proxy_bin", return_value="/usr/bin/efs-proxy")
+    with mount_efs.bootstrap_proxy(
+        MOCK_CONFIG,
+        INIT_SYSTEM,
+        DNS_NAME,
+        FS_ID,
+        MOUNT_POINT,
+        {"tls": None},
+        state_file_dir,
+        efs_proxy_enabled=True,
+    ):
+        pass
+
+    popen_args, _ = popen_mock.call_args
+    popen_args = popen_args[0]
+
+    assert "/usr/bin/efs-proxy" in popen_args
+    assert "--tls" in popen_args
+    assert EXPECTED_STUNNEL_CONFIG_FILE in popen_args
+
+
+def test_bootstrap_proxy_efs_proxy_enabled_non_tls(mocker, tmpdir):
+    popen_mock, _ = setup_mocks(mocker)
+    mocker.patch("os.rename")
+    state_file_dir = str(tmpdir)
+    mocker.patch("mount_efs.is_ocsp_enabled", return_value=False)
+    mocker.patch("mount_efs._efs_proxy_bin", return_value="/usr/bin/efs-proxy")
+    with mount_efs.bootstrap_proxy(
+        MOCK_CONFIG,
+        INIT_SYSTEM,
+        DNS_NAME,
+        FS_ID,
+        MOUNT_POINT,
+        {},
+        state_file_dir,
+        efs_proxy_enabled=True,
+    ):
+        pass
+
+    popen_args, _ = popen_mock.call_args
+    popen_args = popen_args[0]
+
+    assert "/usr/bin/stunnel" not in popen_args
+    assert "--tls" not in popen_args
+
+    assert "/usr/bin/efs-proxy" in popen_args
+    assert EXPECTED_STUNNEL_CONFIG_FILE in popen_args
+
+
+def test_bootstrap_proxy_stunnel_enabled(mocker, tmpdir):
+    popen_mock, _ = setup_mocks(mocker)
+    mocker.patch("os.rename")
+    state_file_dir = str(tmpdir)
+
+    mocker.patch("mount_efs._stunnel_bin", return_value="/usr/bin/stunnel")
+    with mount_efs.bootstrap_proxy(
+        MOCK_CONFIG,
+        INIT_SYSTEM,
+        DNS_NAME,
+        FS_ID,
+        MOUNT_POINT,
+        {},
+        state_file_dir,
+        efs_proxy_enabled=False,
+    ):
+        pass
+
+    popen_args, _ = popen_mock.call_args
+    popen_args = popen_args[0]
+
+    assert "/usr/bin/efs-proxy" not in popen_args
+    assert "info" not in popen_args
+
+    assert "/usr/bin/stunnel" in popen_args
+    assert EXPECTED_STUNNEL_CONFIG_FILE in popen_args
+
+
+def test_bootstrap_proxy_netns_option(mocker, tmpdir):
+    popen_mock, write_config_mock = setup_mocks(mocker)
+    state_file_dir = str(tmpdir)
+
+    netns = "/proc/1/net/ns"
+    mocker.patch("mount_efs._efs_proxy_bin", return_value="/usr/bin/efs-proxy")
+    mocker.patch("mount_efs.NetNS")
+    mocker.patch("mount_efs.is_ocsp_enabled", return_value=False)
+    with mount_efs.bootstrap_proxy(
+        MOCK_CONFIG,
+        INIT_SYSTEM,
+        DNS_NAME,
+        FS_ID,
+        MOUNT_POINT,
+        {"netns": netns},
+        state_file_dir,
+    ):
+        pass
+
+    popen_args, _ = popen_mock.call_args
+    popen_args = popen_args[0]
+    write_config_args, _ = write_config_mock.call_args
+
+    assert "/usr/bin/efs-proxy" in popen_args
+    assert EXPECTED_STUNNEL_CONFIG_FILE in popen_args
+    assert "nsenter" in popen_args
+    assert "--net=" + netns in popen_args

--- a/test/mount_efs_test/test_mount_with_proxy.py
+++ b/test/mount_efs_test/test_mount_with_proxy.py
@@ -1,0 +1,221 @@
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+import mount_efs
+
+from .. import common, utils
+
+try:
+    import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+
+try:
+    import ConfigParser
+except ImportError:
+    from configparser import ConfigParser
+
+DNS_NAME = "fs-deadbeef.efs.us-east-1.amazonaws.com"
+FS_ID = "fs-deadbeef"
+INIT_SYSTEM = "upstart"
+FALLBACK_IP_ADDRESS = "192.0.0.1"
+MOUNT_POINT = "/mnt"
+PATH = "/"
+
+DEFAULT_OPTIONS = {
+    "nfsvers": 4.1,
+    "rsize": 1048576,
+    "wsize": 1048576,
+    "hard": None,
+    "timeo": 600,
+    "retrans": 2,
+    "tlsport": 3049,
+}
+
+# indices of different arguments to the NFS call
+NFS_BIN_ARG_IDX = 0
+NFS_MOUNT_PATH_IDX = 1
+NFS_MOUNT_POINT_IDX = 2
+NFS_OPTION_FLAG_IDX = 3
+NFS_OPTIONS_IDX = 4
+
+# indices of different arguments to the NFS call to certain network namespace
+NETNS_NSENTER_ARG_IDX = 0
+NETNS_PATH_ARG_IDX = 1
+NETNS_NFS_OFFSET = 2
+
+# indices of different arguments to the NFS call for MACOS
+NFS_MOUNT_PATH_IDX_MACOS = -2
+NFS_MOUNT_POINT_IDX_MACOS = -1
+
+NETNS = "/proc/1/net/ns"
+
+
+def _get_config(ocsp_enabled=False):
+    try:
+        config = ConfigParser.SafeConfigParser()
+    except AttributeError:
+        config = ConfigParser()
+
+    mount_nfs_command_retry_count = 4
+    mount_nfs_command_retry_timeout = 10
+    mount_nfs_command_retry = "false"
+    config.add_section(mount_efs.CONFIG_SECTION)
+    config.set(
+        mount_efs.CONFIG_SECTION, "retry_nfs_mount_command", mount_nfs_command_retry
+    )
+    config.set(
+        mount_efs.CONFIG_SECTION,
+        "retry_nfs_mount_command_count",
+        str(mount_nfs_command_retry_count),
+    )
+    config.set(
+        mount_efs.CONFIG_SECTION,
+        "retry_nfs_mount_command_timeout_sec",
+        str(mount_nfs_command_retry_timeout),
+    )
+    if ocsp_enabled:
+        config.set(
+            mount_efs.CONFIG_SECTION,
+            "stunnel_check_cert_validity",
+            "true",
+        )
+    return config
+
+
+def _mock_popen(mocker, returncode=0, stdout="stdout", stderr="stderr"):
+    popen_mock = MagicMock()
+    popen_mock.communicate.return_value = (
+        stdout,
+        stderr,
+    )
+    popen_mock.returncode = returncode
+
+    return mocker.patch("subprocess.Popen", return_value=popen_mock)
+
+
+def test_mount_with_proxy_efs_proxy_enabled(mocker, capsys):
+    options = dict(DEFAULT_OPTIONS)
+    options["tls"] = None
+
+    bootstrap_proxy_mock = mocker.patch("mount_efs.bootstrap_proxy")
+    mocker.patch("os.path.ismount", return_value=False)
+    mocker.patch("threading.Thread.start")
+    mocker.patch("threading.Thread.join")
+    mocker.patch("mount_efs.mount_nfs")
+    _mock_popen(mocker, stdout="nfs")
+    mount_efs.mount_with_proxy(
+        _get_config(),
+        INIT_SYSTEM,
+        DNS_NAME,
+        PATH,
+        FS_ID,
+        MOUNT_POINT,
+        options,
+    )
+    utils.assert_called_once(bootstrap_proxy_mock)
+
+    kwargs = bootstrap_proxy_mock.call_args[1]
+    assert kwargs["efs_proxy_enabled"] == True
+
+
+def test_mount_with_proxy_ocsp_config_enabled(mocker, capsys):
+    options = dict(DEFAULT_OPTIONS)
+    options["tls"] = None
+
+    bootstrap_proxy_mock = mocker.patch("mount_efs.bootstrap_proxy")
+    mocker.patch("os.path.ismount", return_value=False)
+    mocker.patch("threading.Thread.start")
+    mocker.patch("threading.Thread.join")
+    mocker.patch("mount_efs.mount_nfs")
+    _mock_popen(mocker, stdout="nfs")
+    mount_efs.mount_with_proxy(
+        _get_config(ocsp_enabled=True),
+        INIT_SYSTEM,
+        DNS_NAME,
+        PATH,
+        FS_ID,
+        MOUNT_POINT,
+        options,
+    )
+    utils.assert_called_once(bootstrap_proxy_mock)
+
+    kwargs = bootstrap_proxy_mock.call_args[1]
+    assert kwargs["efs_proxy_enabled"] == False
+
+
+def test_mount_with_proxy_ocsp_option_enabled(mocker, capsys):
+    options = dict(DEFAULT_OPTIONS)
+    options["tls"] = None
+    options["ocsp"] = None
+
+    bootstrap_proxy_mock = mocker.patch("mount_efs.bootstrap_proxy")
+    mocker.patch("os.path.ismount", return_value=False)
+    mocker.patch("threading.Thread.start")
+    mocker.patch("threading.Thread.join")
+    mocker.patch("mount_efs.mount_nfs")
+    _mock_popen(mocker, stdout="nfs")
+    mount_efs.mount_with_proxy(
+        _get_config(),
+        INIT_SYSTEM,
+        DNS_NAME,
+        PATH,
+        FS_ID,
+        MOUNT_POINT,
+        options,
+    )
+    utils.assert_called_once(bootstrap_proxy_mock)
+
+    kwargs = bootstrap_proxy_mock.call_args[1]
+    assert kwargs["efs_proxy_enabled"] == False
+
+
+def test_mount_with_proxy_efs_proxy_enabled_non_tls_mount(mocker, capsys):
+    options = dict(DEFAULT_OPTIONS)
+
+    bootstrap_proxy_mock = mocker.patch("mount_efs.bootstrap_proxy")
+    mocker.patch("os.path.ismount", return_value=False)
+    mocker.patch("threading.Thread.start")
+    mocker.patch("threading.Thread.join")
+    mocker.patch("mount_efs.mount_nfs")
+    _mock_popen(mocker, stdout="nfs")
+    mount_efs.mount_with_proxy(
+        _get_config(),
+        INIT_SYSTEM,
+        DNS_NAME,
+        PATH,
+        FS_ID,
+        MOUNT_POINT,
+        options,
+    )
+    utils.assert_called_once(bootstrap_proxy_mock)
+
+    kwargs = bootstrap_proxy_mock.call_args[1]
+    assert kwargs["efs_proxy_enabled"] == True
+
+
+def test_mount_with_proxy_stunnel_enabled(mocker, capsys):
+    options = dict(DEFAULT_OPTIONS)
+    options["stunnel"] = None
+
+    bootstrap_proxy_mock = mocker.patch("mount_efs.bootstrap_proxy")
+    mocker.patch("os.path.ismount", return_value=False)
+    mocker.patch("threading.Thread.start")
+    mocker.patch("threading.Thread.join")
+    mocker.patch("mount_efs.mount_nfs")
+    _mock_popen(mocker, stdout="nfs")
+    mount_efs.mount_with_proxy(
+        _get_config(),
+        INIT_SYSTEM,
+        DNS_NAME,
+        PATH,
+        FS_ID,
+        MOUNT_POINT,
+        options,
+    )
+    utils.assert_called_once(bootstrap_proxy_mock)
+
+    kwargs = bootstrap_proxy_mock.call_args[1]
+    assert kwargs["efs_proxy_enabled"] == False

--- a/test/mount_efs_test/test_write_tls_tunnel_state_file.py
+++ b/test/mount_efs_test/test_write_tls_tunnel_state_file.py
@@ -22,7 +22,7 @@ FILES = ["/tmp/foo", "/tmp/bar"]
 DATETIME_FORMAT = "%y%m%d%H%M%SZ"
 
 
-def test_write_tls_tunnel_state_file_netns(tmpdir):
+def test_write_tunnel_state_file_netns(tmpdir):
     state_file_dir = str(tmpdir)
 
     mount_point = "/home/user/foo/mount"
@@ -42,7 +42,7 @@ def test_write_tls_tunnel_state_file_netns(tmpdir):
         "useIam": True,
     }
 
-    state_file = mount_efs.write_tls_tunnel_state_file(
+    state_file = mount_efs.write_tunnel_state_file(
         FS_ID,
         mount_point,
         PORT,
@@ -80,7 +80,7 @@ def test_write_tls_tunnel_state_file_netns(tmpdir):
     assert cert_details["useIam"] == state.get("useIam")
 
 
-def test_write_tls_tunnel_state_file(tmpdir):
+def test_write_tunnel_state_file(tmpdir):
     state_file_dir = str(tmpdir)
 
     mount_point = "/home/user/foo/mount"
@@ -100,7 +100,7 @@ def test_write_tls_tunnel_state_file(tmpdir):
         "useIam": True,
     }
 
-    state_file = mount_efs.write_tls_tunnel_state_file(
+    state_file = mount_efs.write_tunnel_state_file(
         FS_ID, mount_point, PORT, PID, COMMAND, FILES, state_file_dir, cert_details
     )
 
@@ -131,12 +131,12 @@ def test_write_tls_tunnel_state_file(tmpdir):
     assert cert_details["useIam"] == state.get("useIam")
 
 
-def test_write_tls_tunnel_state_file_no_cert(tmpdir):
+def test_write_tunnel_state_file_no_cert(tmpdir):
     state_file_dir = str(tmpdir)
 
     mount_point = "/home/user/foo/mount"
 
-    state_file = mount_efs.write_tls_tunnel_state_file(
+    state_file = mount_efs.write_tunnel_state_file(
         FS_ID, mount_point, PORT, PID, COMMAND, FILES, state_file_dir
     )
 

--- a/test/watchdog_test/test_send_signal_to_stunnel_processes.py
+++ b/test/watchdog_test/test_send_signal_to_stunnel_processes.py
@@ -93,7 +93,7 @@ def test_is_mount_stunnel_proc_running_process_not_stunnel(mocker, tmpdir):
 
     assert False == watchdog.is_mount_stunnel_proc_running(PID, STATE_FILE, tmpdir)
     debug_log = mock_log_debug.call_args[0][0]
-    assert "is not a stunnel process" in debug_log
+    assert "is not an efs-proxy or stunnel process" in debug_log
 
 
 def test_is_mount_stunnel_proc_running_process_not_running(mocker, tmpdir):


### PR DESCRIPTION
### Summary
This commit replaces stunnel, which provides TLS encryptions for mounts, with efs-proxy, a component built in-house at AWS. Efs-proxy lays the foundation for upcoming feature launches at EFS.

For details on upgrading to efs-utils v2.0.0, see the readme section, "Upgrading from efs-utils v1 to v2".

### Testing
We've performed internal functional, performance, robustness, and chaos testing, to ensure that efs-proxy meets the high bar expected of AWS software.

[Circleci tests passed here](https://app.circleci.com/pipelines/github/RyanStan/efs-utils/10/workflows/51031ca8-a082-45da-b6b8-9c8144f5897d).