### PR TITLE
efs-utils v2.0.1 release

### DIFF
--- a/amazon-efs-utils.spec
+++ b/amazon-efs-utils.spec
@@ -37,12 +37,12 @@
 %endif
 
 %global proxy_name efs-proxy
-%global proxy_version 2.0.0
+%global proxy_version 2.0.1
 
 %{?!include_vendor_tarball:%define include_vendor_tarball true}
 
 Name      : amazon-efs-utils
-Version   : 2.0.0
+Version   : 2.0.1
 Release   : 1%{platform}
 Summary   : This package provides utilities for simplifying the use of EFS file systems
 
@@ -169,6 +169,9 @@ fi
 %clean
 
 %changelog
+* Mon Apr 23 2024 Ryan Stankiewicz <rjstank@amazon.com> - 2.0.1
+- Disable Nagle's algorithm for efs-proxy TLS mounts to improve latencies 
+
 * Mon Apr 08 2024 Ryan Stankiewicz <rjstank@amazon.com> - 2.0.0
 - Replace stunnel, which provides TLS encryptions for mounts, with efs-proxy, a component built in-house at AWS. Efs-proxy lays the foundation for upcoming feature launches at EFS. 
 

--- a/build-deb.sh
+++ b/build-deb.sh
@@ -11,7 +11,7 @@ set -ex
 
 BASE_DIR=$(pwd)
 BUILD_ROOT=${BASE_DIR}/build/debbuild
-VERSION=2.0.0
+VERSION=2.0.1
 RELEASE=1
 DEB_SYSTEM_RELEASE_PATH=/etc/os-release
 

--- a/config.ini
+++ b/config.ini
@@ -7,5 +7,5 @@
 #
 
 [global]
-version=2.0.0
+version=2.0.1
 release=1

--- a/dist/amazon-efs-utils.control
+++ b/dist/amazon-efs-utils.control
@@ -1,6 +1,6 @@
 Package: amazon-efs-utils
 Architecture: all
-Version: 2.0.0
+Version: 2.0.1
 Section: utils
 Depends: python3, nfs-common, stunnel4 (>= 4.56), openssl (>= 1.0.2), util-linux
 Priority: optional

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -85,7 +85,7 @@ except ImportError:
     BOTOCORE_PRESENT = False
 
 
-VERSION = "2.0.0"
+VERSION = "2.0.1"
 SERVICE = "elasticfilesystem"
 
 AMAZON_LINUX_2_RELEASE_ID = "Amazon Linux release 2 (Karoo)"

--- a/src/proxy/Cargo.toml
+++ b/src/proxy/Cargo.toml
@@ -3,7 +3,7 @@ name = "efs-proxy"
 edition = "2021"
 build = "build.rs"
 # The version of efs-proxy is tied to efs-utils.
-version = "2.0.0"
+version = "2.0.1"
 publish = false
 
 [dependencies]

--- a/src/proxy/src/tls.rs
+++ b/src/proxy/src/tls.rs
@@ -9,6 +9,7 @@ use s2n_tls_tokio::TlsStream;
 use std::path::Path;
 use tokio::net::TcpStream;
 
+use crate::connections::configure_stream;
 use crate::error::ConnectError;
 
 pub const FIPS_COMPLIANT_POLICY_VERSION: &str = "20230317";
@@ -138,7 +139,7 @@ pub async fn establish_tls_stream(
 
     let tls_connector = TlsConnector::new(config);
 
-    let tcp_stream = TcpStream::connect(tls_config.remote_addr).await?;
+    let tcp_stream = configure_stream(TcpStream::connect(tls_config.remote_addr).await?);
 
     let tls_stream = tls_connector
         .connect(&tls_config.server_domain, tcp_stream)

--- a/src/watchdog/__init__.py
+++ b/src/watchdog/__init__.py
@@ -56,7 +56,7 @@ AMAZON_LINUX_2_RELEASE_VERSIONS = [
     AMAZON_LINUX_2_RELEASE_ID,
     AMAZON_LINUX_2_PRETTY_NAME,
 ]
-VERSION = "2.0.0"
+VERSION = "2.0.1"
 SERVICE = "elasticfilesystem"
 
 CONFIG_FILE = "/etc/amazon/efs/efs-utils.conf"


### PR DESCRIPTION
*Description of changes:*
Nagles algorithm - buffering small TCP packets - causes latencies to dramatically increase on some NFS workloads where the IO size is greater than the MTU size.

*Testing*
A file create, write 8KB, read, close, remove, workload goes from about 80 ms to 20 ms after we enable NO_DELAY.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
