### PR TITLE
Amend Debian control to use binary architecture

### DIFF
--- a/build-deb.sh
+++ b/build-deb.sh
@@ -13,7 +13,9 @@ BASE_DIR=$(pwd)
 BUILD_ROOT=${BASE_DIR}/build/debbuild
 VERSION=2.0.1
 RELEASE=1
+ARCH=$(dpkg-architecture -qDEB_BUILD_ARCH)
 DEB_SYSTEM_RELEASE_PATH=/etc/os-release
+export VERSION RELEASE ARCH
 
 echo 'Cleaning deb build workspace'
 rm -rf ${BUILD_ROOT}
@@ -47,8 +49,9 @@ install -p -m 755 dist/scriptlets/after-install-upgrade ${BUILD_ROOT}/postinst
 install -p -m 755 dist/scriptlets/before-remove ${BUILD_ROOT}/prerm
 install -p -m 755 dist/scriptlets/after-remove ${BUILD_ROOT}/postrm
 
-echo 'Copying control file'
-install -p -m 644 dist/amazon-efs-utils.control ${BUILD_ROOT}/control
+echo 'Generating control file'
+envsubst < dist/amazon-efs-utils.control > ${BUILD_ROOT}/control
+chmod 644 ${BUILD_ROOT}/control
 
 echo 'Copying conffiles'
 install -p -m 644 dist/amazon-efs-utils.conffiles ${BUILD_ROOT}/conffiles
@@ -69,7 +72,7 @@ tar czf data.tar.gz etc sbin usr var --owner=0 --group=0
 cd ${BASE_DIR}
 
 echo 'Building deb'
-DEB=${BUILD_ROOT}/amazon-efs-utils-${VERSION}-${RELEASE}_all.deb
+DEB=${BUILD_ROOT}/amazon-efs-utils-${VERSION}-${RELEASE}_${ARCH}.deb
 ar r ${DEB} ${BUILD_ROOT}/debian-binary
 ar r ${DEB} ${BUILD_ROOT}/control.tar.gz
 ar r ${DEB} ${BUILD_ROOT}/data.tar.gz

--- a/dist/amazon-efs-utils.control
+++ b/dist/amazon-efs-utils.control
@@ -1,6 +1,6 @@
 Package: amazon-efs-utils
-Architecture: all
-Version: 2.0.1
+Architecture: $ARCH
+Version: $VERSION-$RELEASE
 Section: utils
 Depends: python3, nfs-common, stunnel4 (>= 4.56), openssl (>= 1.0.2), util-linux
 Priority: optional


### PR DESCRIPTION
The debian package built includes a binary for a specific architecture, which makes the use of the "all" architecture problematic in multi-architecture environments.

This change parameterises the control file, and the package filename, to reflect the build arch. To aid in future versioning consistency, I've included parameterisation of the version number as well.
