### PR TITLE
bump py fom 1.10.0 to 1.11.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ mccabe==0.6.1
 mock==2.0.0
 pbr==3.1.1
 pluggy==0.13.0
-py==1.10.0
+py==1.11.0
 pycodestyle==2.5.0
 pyflakes==2.1.1
 pytest==4.6.7


### PR DESCRIPTION
Resolve issue #214 

Bump `py` from `1.10.0` to `1.11.0`
