### PR TITLE
Use timezone-aware objects to resolve DeprecationWarning with Python 3.12

### DIFF
--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -47,7 +47,7 @@ import sys
 import threading
 import time
 from contextlib import contextmanager
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from logging.handlers import RotatingFileHandler
 
 try:
@@ -2540,7 +2540,7 @@ def get_utc_now():
     """
     Wrapped for patching purposes in unit tests
     """
-    return datetime.utcnow()
+    return datetime.now(timezone.utc)
 
 
 def assert_root():

--- a/src/watchdog/__init__.py
+++ b/src/watchdog/__init__.py
@@ -25,7 +25,7 @@ import sys
 import time
 from collections import namedtuple
 from contextlib import contextmanager
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from logging.handlers import RotatingFileHandler
 from signal import SIGHUP, SIGKILL, SIGTERM
 
@@ -1401,7 +1401,7 @@ def check_certificate(
 ):
     certificate_creation_time = datetime.strptime(
         state["certificateCreationTime"], CERT_DATETIME_FORMAT
-    )
+    ).replace(tzinfo=timezone.utc)
     certificate_exists = os.path.isfile(state["certificate"])
     certificate_renewal_interval_secs = (
         get_certificate_renewal_interval_mins(config) * 60
@@ -2060,7 +2060,7 @@ def get_utc_now():
     """
     Wrapped for patching purposes in unit tests
     """
-    return datetime.utcnow()
+    return datetime.now(timezone.utc)
 
 
 def check_process_name(pid):


### PR DESCRIPTION
*Issue #, if available: #187*

*Description of changes:*
This PR fixes a deprecation that came up with the datetime library under Python 3.12. The watchdog is currently spamming the deprecation warning 2 times per seconds / 120 times per minute into the syslog - fixing the deprecation will resolve this issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
