### PR TITLE
efs-utils v2.0.3 release

### DIFF
--- a/amazon-efs-utils.spec
+++ b/amazon-efs-utils.spec
@@ -41,7 +41,7 @@
 %{?!include_vendor_tarball:%define include_vendor_tarball true}
 
 Name      : amazon-efs-utils
-Version   : 2.0.2
+Version   : 2.0.3
 Release   : 1%{platform}
 Summary   : This package provides utilities for simplifying the use of EFS file systems
 
@@ -168,6 +168,10 @@ fi
 %clean
 
 %changelog
+* Tue Jun 18 2024 Arnav Gupta <arnavgup@amazon.com> - 2.0.3
+- Upgrade py version
+- Replace deprecated usage of datetime 
+
 * Mon May 20 2024 Anthony Tse <anthotse@amazon.com> - 2.0.2
 - Check for efs-proxy PIDs when cleaning tunnel state files
 - Add PID to log entries

--- a/build-deb.sh
+++ b/build-deb.sh
@@ -11,7 +11,7 @@ set -ex
 
 BASE_DIR=$(pwd)
 BUILD_ROOT=${BASE_DIR}/build/debbuild
-VERSION=2.0.2
+VERSION=2.0.3
 RELEASE=1
 DEB_SYSTEM_RELEASE_PATH=/etc/os-release
 

--- a/config.ini
+++ b/config.ini
@@ -7,5 +7,5 @@
 #
 
 [global]
-version=2.0.2
+version=2.0.3
 release=1

--- a/dist/amazon-efs-utils.control
+++ b/dist/amazon-efs-utils.control
@@ -1,6 +1,6 @@
 Package: amazon-efs-utils
 Architecture: all
-Version: 2.0.2
+Version: 2.0.3
 Section: utils
 Depends: python3, nfs-common, stunnel4 (>= 4.56), openssl (>= 1.0.2), util-linux
 Priority: optional

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ mccabe==0.6.1
 mock==2.0.0
 pbr==3.1.1
 pluggy==0.13.0
-py==1.10.0
+py==1.11.0
 pycodestyle==2.5.0
 pyflakes==2.1.1
 pytest==4.6.7

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -47,7 +47,7 @@ import sys
 import threading
 import time
 from contextlib import contextmanager
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from logging.handlers import RotatingFileHandler
 
 try:
@@ -85,7 +85,7 @@ except ImportError:
     BOTOCORE_PRESENT = False
 
 
-VERSION = "2.0.2"
+VERSION = "2.0.3"
 SERVICE = "elasticfilesystem"
 
 AMAZON_LINUX_2_RELEASE_ID = "Amazon Linux release 2 (Karoo)"
@@ -2540,7 +2540,7 @@ def get_utc_now():
     """
     Wrapped for patching purposes in unit tests
     """
-    return datetime.utcnow()
+    return datetime.now(timezone.utc)
 
 
 def assert_root():

--- a/src/proxy/Cargo.toml
+++ b/src/proxy/Cargo.toml
@@ -3,7 +3,7 @@ name = "efs-proxy"
 edition = "2021"
 build = "build.rs"
 # The version of efs-proxy is tied to efs-utils.
-version = "2.0.2"
+version = "2.0.3"
 publish = false
 
 [dependencies]

--- a/src/watchdog/__init__.py
+++ b/src/watchdog/__init__.py
@@ -25,7 +25,7 @@ import sys
 import time
 from collections import namedtuple
 from contextlib import contextmanager
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from logging.handlers import RotatingFileHandler
 from signal import SIGHUP, SIGKILL, SIGTERM
 
@@ -56,7 +56,7 @@ AMAZON_LINUX_2_RELEASE_VERSIONS = [
     AMAZON_LINUX_2_RELEASE_ID,
     AMAZON_LINUX_2_PRETTY_NAME,
 ]
-VERSION = "2.0.2"
+VERSION = "2.0.3"
 SERVICE = "elasticfilesystem"
 
 CONFIG_FILE = "/etc/amazon/efs/efs-utils.conf"
@@ -1408,7 +1408,7 @@ def check_certificate(
     )
     # creation instead of NOT_BEFORE datetime is used for refresh of cert because NOT_BEFORE derives from creation datetime
     should_refresh_cert = (
-        get_utc_now() - certificate_creation_time
+        get_utc_now() - certificate_creation_time.replace(tzinfo=timezone.utc)
     ).total_seconds() > certificate_renewal_interval_secs
 
     if certificate_exists and not should_refresh_cert:
@@ -2060,7 +2060,7 @@ def get_utc_now():
     """
     Wrapped for patching purposes in unit tests
     """
-    return datetime.utcnow()
+    return datetime.now(timezone.utc)
 
 
 def check_process_name(pid):

--- a/test/watchdog_test/test_refresh_self_signed_certificate.py
+++ b/test/watchdog_test/test_refresh_self_signed_certificate.py
@@ -7,7 +7,7 @@
 import json
 import logging
 import os
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -34,7 +34,7 @@ CREDENTIALS_SOURCE = "credentials:default"
 ACCESS_KEY_ID_VAL = "FAKE_AWS_ACCESS_KEY_ID"
 SECRET_ACCESS_KEY_VAL = "FAKE_AWS_SECRET_ACCESS_KEY"
 SESSION_TOKEN_VAL = "FAKE_SESSION_TOKEN"
-FIXED_DT = datetime(2000, 1, 1, 12, 0, 0)
+FIXED_DT = datetime(2000, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
 CLIENT_INFO = {"source": "test", "efs_utils_version": watchdog.VERSION}
 CREDENTIALS = {
     "AccessKeyId": ACCESS_KEY_ID_VAL,
@@ -472,7 +472,9 @@ def test_refresh_self_signed_certificate_send_sighup(mocker, tmpdir, caplog):
 
     config = _get_config()
     pk_path = _get_mock_private_key_path(mocker, tmpdir)
-    four_hours_back = (datetime.utcnow() - timedelta(hours=4)).strftime(DT_PATTERN)
+    four_hours_back = (datetime.now(timezone.utc) - timedelta(hours=4)).strftime(
+        DT_PATTERN
+    )
     tls_dict = watchdog.tls_paths_dictionary(MOUNT_NAME, str(tmpdir))
     state = _create_certificate_and_state(
         tls_dict, str(tmpdir), pk_path, four_hours_back, ap_id=AP_ID
@@ -494,7 +496,9 @@ def test_refresh_self_signed_certificate_pid_not_running(mocker, tmpdir, caplog)
 
     config = _get_config()
     pk_path = _get_mock_private_key_path(mocker, tmpdir)
-    four_hours_back = (datetime.utcnow() - timedelta(hours=4)).strftime(DT_PATTERN)
+    four_hours_back = (datetime.now(timezone.utc) - timedelta(hours=4)).strftime(
+        DT_PATTERN
+    )
     tls_dict = watchdog.tls_paths_dictionary(MOUNT_NAME, str(tmpdir))
     state = _create_certificate_and_state(
         tls_dict, str(tmpdir), pk_path, four_hours_back, False, ap_id=AP_ID


### PR DESCRIPTION
efs-utils v2.0.3:

- Upgrade py version
- Replace deprecated usage of datetime 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
