### PR TITLE
Remove outdated python versions from CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,18 +238,6 @@ workflows:
       - test:
           name: python3_8
           image: python:3.8.13
-      - test:
-          name: python3_7
-          image: python:3.7.13
-      - test:
-          name: python3_6
-          image: python:3.6.15
-      - test:
-          name: python3_5
-          image: python:3.5.10
-      - test:
-          name: python3_4
-          image: python:3.4.10
       - build-deb-package:
           name: ubuntu-latest
           image: ubuntu:latest

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ The `efs-utils` package has been verified against the following MacOS distributi
 
 * `nfs-utils` (RHEL/CentOS/Amazon Linux/Fedora) or `nfs-common` (Debian/Ubuntu)
 * OpenSSL-devel 1.0.2+
-* Python 3.4+
+* Python 3.7/3.8
 * `stunnel` 4.56+
 - `rust` 1.68+
 - `cargo`


### PR DESCRIPTION
*Description of changes:*
Remove outdated python versions from CircleCI.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
