### PR TITLE
Adding region-specifc domain suffix for sts endpoints and adding new regions and domain suffixes

### DIFF
--- a/dist/efs-utils.conf
+++ b/dist/efs-utils.conf
@@ -57,10 +57,8 @@ retry_nfs_mount_command_timeout_sec = 15
 [mount.cn-north-1]
 dns_name_suffix = amazonaws.com.cn
 
-
 [mount.cn-northwest-1]
 dns_name_suffix = amazonaws.com.cn
-
 
 [mount.us-iso-east-1]
 dns_name_suffix = c2s.ic.gov
@@ -72,6 +70,22 @@ stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 [mount.us-isob-east-1]
 dns_name_suffix = sc2s.sgov.gov
+stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+
+[mount.us-isob-west-1]
+dns_name_suffix = sc2s.sgov.gov
+stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+
+[mount.us-isof-east-1]
+dns_name_suffix = csp.hci.ic.gov
+stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+
+[mount.us-isof-south-1]
+dns_name_suffix = csp.hci.ic.gov
+stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+
+[mount.eu-isoe-west-1]
+dns_name_suffix = cloud.adc-e.uk
 stunnel_cafile = /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 
 [mount-watchdog]

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -195,7 +195,7 @@ AP_ID_RE = re.compile("^fsap-[0-9a-f]{17}$")
 
 CREDENTIALS_KEYS = ["AccessKeyId", "SecretAccessKey", "Token"]
 ECS_TASK_METADATA_API = "http://169.254.170.2"
-STS_ENDPOINT_URL_FORMAT = "https://sts.{}.amazonaws.com/"
+STS_ENDPOINT_URL_FORMAT = "https://sts.{}.{}/"
 INSTANCE_METADATA_TOKEN_URL = "http://169.254.169.254/latest/api/token"
 INSTANCE_METADATA_SERVICE_URL = (
     "http://169.254.169.254/latest/dynamic/instance-identity/document/"
@@ -403,6 +403,22 @@ def get_target_region(config):
         logging.warning('Legacy check for region in "dns_name_format" failed')
 
     _fatal_error(metadata_exception)
+
+def get_target_domain_suffix(config):
+    def _fatal_error():
+        fatal_error(
+            'Error retrieving region. Please set the "dns_name_suffix" parameter '
+            "in the efs-utils configuration file."
+        )
+    region = get_target_region(config)
+    config_section = get_config_section(config, region)
+
+    try:
+        return config.get(config_section, "dns_name_suffix")
+    except NoOptionError:
+        pass
+
+    _fatal_error()
 
 
 def get_target_az(config, options):
@@ -686,6 +702,7 @@ def get_aws_security_credentials(
     config,
     use_iam,
     region,
+    dns_name_suffix,
     awsprofile=None,
     aws_creds_uri=None,
     jwt_path=None,
@@ -730,6 +747,7 @@ def get_aws_security_credentials(
             role_arn,
             jwt_path,
             region,
+            dns_name_suffix,
             False,
         )
         if credentials and credentials_source:
@@ -744,6 +762,7 @@ def get_aws_security_credentials(
             os.environ[WEB_IDENTITY_ROLE_ARN_ENV],
             os.environ[WEB_IDENTITY_TOKEN_FILE_ENV],
             region,
+            dns_name_suffix,
             False,
         )
         if credentials and credentials_source:
@@ -817,7 +836,7 @@ def get_aws_security_credentials_from_ecs(config, aws_creds_uri, is_fatal=False)
 
 
 def get_aws_security_credentials_from_webidentity(
-    config, role_arn, token_file, region, is_fatal=False
+    config, role_arn, token_file, region, dns_name_suffix, is_fatal=False
 ):
     try:
         with open(token_file, "r") as f:
@@ -829,7 +848,7 @@ def get_aws_security_credentials_from_webidentity(
         else:
             return None, None
 
-    STS_ENDPOINT_URL = STS_ENDPOINT_URL_FORMAT.format(region)
+    STS_ENDPOINT_URL = STS_ENDPOINT_URL_FORMAT.format(region,dns_name_suffix)
     webidentity_url = (
         STS_ENDPOINT_URL
         + "?"
@@ -1748,6 +1767,7 @@ def bootstrap_proxy(
         security_credentials = None
         client_info = get_client_info(config)
         region = get_target_region(config)
+        dns_name_suffix = get_target_domain_suffix(config)
 
         if tls_enabled(options):
             cert_details = {}
@@ -1764,7 +1784,7 @@ def bootstrap_proxy(
                     kwargs = {"awsprofile": get_aws_profile(options, use_iam)}
 
                 security_credentials, credentials_source = get_aws_security_credentials(
-                    config, use_iam, region, **kwargs
+                    config, use_iam, region, dns_name_suffix, **kwargs
                 )
 
                 if credentials_source:
@@ -2663,7 +2683,8 @@ def get_dns_name_and_fallback_mount_target_ip_address(config, fs_id, options):
         try:
             az_id = get_az_id_from_instance_metadata(config, options)
             region = get_target_region(config)
-            dns_name = "%s.%s.efs.%s.amazonaws.com" % (az_id, fs_id, region)
+            dns_name_suffix = get_target_domain_suffix(config)
+            dns_name = "%s.%s.efs.%s.%s" % (az_id, fs_id, region, dns_name_suffix)
         except RuntimeError:
             err_msg = "Cannot retrieve AZ-ID from metadata service. This is required for the crossaccount mount option."
             fatal_error(err_msg)

--- a/src/mount_efs/__init__.py
+++ b/src/mount_efs/__init__.py
@@ -1766,7 +1766,7 @@ def bootstrap_proxy(
         cert_details = None
         security_credentials = None
         client_info = get_client_info(config)
-        region = get_target_region(config)
+        region = get_target_region(config, options)
         dns_name_suffix = get_target_domain_suffix(config)
 
         if tls_enabled(options):

--- a/test/mount_efs_test/test_bootstrap_proxy.py
+++ b/test/mount_efs_test/test_bootstrap_proxy.py
@@ -16,6 +16,7 @@ CLIENT_SOURCE = "test"
 DNS_NAME = "%s.efs.us-east-1.amazonaws.com" % FS_ID
 MOUNT_POINT = "/mnt"
 REGION = "us-east-1"
+DOMAIN_SUFFIX = "amazonaws.com"
 
 
 DEFAULT_TLS_PORT = 20049
@@ -40,6 +41,7 @@ def setup_mocks(mocker):
         return_value=(DNS_NAME, None),
     )
     mocker.patch("mount_efs.get_target_region", return_value=REGION)
+    mocker.patch("mount_efs.get_target_domain_suffix", return_value=DOMAIN_SUFFIX)
     mocker.patch("mount_efs.write_tunnel_state_file", return_value="~mocktempfile")
     mocker.patch("mount_efs.create_certificate")
     mocker.patch("os.rename")
@@ -139,6 +141,7 @@ def test_bootstrap_proxy_cert_created_tls_mount(mocker, tmpdir):
     setup_mocks_without_popen(mocker)
     mocker.patch("mount_efs.get_mount_specific_filename", return_value=DNS_NAME)
     mocker.patch("mount_efs.get_target_region", return_value=REGION)
+    mocker.patch("mount_efs.get_target_domain_suffix", return_value=DOMAIN_SUFFIX)
     state_file_dir = str(tmpdir)
     tls_dict = mount_efs.tls_paths_dictionary(DNS_NAME + "+", state_file_dir)
     mocker.patch("mount_efs.is_ocsp_enabled", return_value=False)
@@ -184,6 +187,7 @@ def test_bootstrap_proxy_cert_not_created_non_tls_mount(mocker, tmpdir):
     setup_mocks_without_popen(mocker)
     mocker.patch("mount_efs.get_mount_specific_filename", return_value=DNS_NAME)
     mocker.patch("mount_efs.get_target_region", return_value=REGION)
+    mocker.patch("mount_efs.get_target_domain_suffix", return_value=DOMAIN_SUFFIX)
     state_file_dir = str(tmpdir)
     tls_dict = mount_efs.tls_paths_dictionary(DNS_NAME + "+", state_file_dir)
 

--- a/test/mount_efs_test/test_get_aws_security_credentials.py
+++ b/test/mount_efs_test/test_get_aws_security_credentials.py
@@ -102,7 +102,7 @@ def test_get_aws_security_credentials_config_or_creds_file_found_creds_found_wit
     mocker.patch("mount_efs.credentials_file_helper", return_value=file_helper_resp)
 
     credentials, credentials_source = mount_efs.get_aws_security_credentials(
-        config, True, "us-east-1", "test_profile"
+        config, True, "us-east-1", "amazonaws.com", "test_profile"
     )
 
     assert credentials["AccessKeyId"] == ACCESS_KEY_ID_VAL
@@ -126,7 +126,7 @@ def test_get_aws_security_credentials_config_or_creds_file_found_creds_found_wit
     mocker.patch("mount_efs.credentials_file_helper", return_value=file_helper_resp)
 
     credentials, credentials_source = mount_efs.get_aws_security_credentials(
-        config, True, "us-east-1", "test_profile"
+        config, True, "us-east-1", "amazonaws.com", "test_profile"
     )
 
     assert credentials["AccessKeyId"] == ACCESS_KEY_ID_VAL
@@ -138,7 +138,7 @@ def test_get_aws_security_credentials_config_or_creds_file_found_creds_found_wit
 def test_get_aws_security_credentials_do_not_use_iam():
     config = get_fake_config()
     credentials, credentials_source = mount_efs.get_aws_security_credentials(
-        config, False, "us-east-1", "test_profile"
+        config, False, "us-east-1", "amazonaws.com", "test_profile"
     )
 
     assert not credentials
@@ -165,7 +165,7 @@ def _test_get_aws_security_credentials_get_ecs_from_env_url(mocker):
     mocker.patch("mount_efs.urlopen", return_value=MockUrlLibResponse(data=response))
 
     credentials, credentials_source = mount_efs.get_aws_security_credentials(
-        config, True, "us-east-1", None
+        config, True, "us-east-1", "amazonaws.com", None
     )
 
     assert credentials["AccessKeyId"] == ACCESS_KEY_ID_VAL
@@ -187,7 +187,7 @@ def test_get_aws_security_credentials_get_ecs_from_option_url(mocker):
     )
     mocker.patch("mount_efs.urlopen", return_value=MockUrlLibResponse(data=response))
     credentials, credentials_source = mount_efs.get_aws_security_credentials(
-        config, True, "us-east-1", None, AWSCREDSURI
+        config, True, "us-east-1", "amazonaws.com", None, AWSCREDSURI
     )
 
     assert credentials["AccessKeyId"] == ACCESS_KEY_ID_VAL
@@ -279,7 +279,7 @@ def _test_get_aws_security_credentials_get_instance_metadata_role_name(
     mocker.patch("mount_efs.urlopen", side_effect=side_effects)
 
     credentials, credentials_source = mount_efs.get_aws_security_credentials(
-        config, True, "us-east-1", None
+        config, True, "us-east-1", "amazonaws.com", None
     )
 
     assert credentials["AccessKeyId"] == ACCESS_KEY_ID_VAL
@@ -295,7 +295,7 @@ def test_get_aws_security_credentials_no_credentials_found(mocker, capsys):
     mocker.patch("mount_efs.urlopen")
 
     with pytest.raises(SystemExit) as ex:
-        mount_efs.get_aws_security_credentials(config, True, "us-east-1", None)
+        mount_efs.get_aws_security_credentials(config, True, "us-east-1", "amazonaws.com", None)
 
     assert 0 != ex.value.code
 
@@ -320,7 +320,7 @@ def test_get_aws_security_credentials_credentials_not_found_in_files_and_botocor
     mount_efs.BOTOCORE_PRESENT = False
 
     with pytest.raises(SystemExit) as ex:
-        mount_efs.get_aws_security_credentials(config, True, "us-east-1", "default")
+        mount_efs.get_aws_security_credentials(config, True, "us-east-1", "amazonaws.com", "default")
 
     assert 0 != ex.value.code
 
@@ -348,7 +348,7 @@ def test_get_aws_security_credentials_botocore_present_get_assumed_profile_crede
     )
 
     credentials, credentials_source = mount_efs.get_aws_security_credentials(
-        config, True, "us-east-1", awsprofile="test-profile"
+        config, True, "us-east-1", "amazonaws.com", awsprofile="test-profile"
     )
     assert credentials["AccessKeyId"] == ACCESS_KEY_ID_VAL
     assert credentials["SecretAccessKey"] == SECRET_ACCESS_KEY_VAL
@@ -365,7 +365,7 @@ def test_get_aws_security_credentials_credentials_not_found_in_aws_creds_uri(
 
     with pytest.raises(SystemExit) as ex:
         mount_efs.get_aws_security_credentials(
-            config, True, "us-east-1", "default", AWSCREDSURI
+            config, True, "us-east-1", "amazonaws.com", "default", AWSCREDSURI
         )
 
     assert 0 != ex.value.code
@@ -474,6 +474,7 @@ def test_get_aws_security_credentials_from_webidentity_passed_in_both_params(moc
         config,
         True,
         "us-east-1",
+        "amazonaws.com",
         jwt_path=WEB_IDENTITY_TOKEN_FILE,
         role_arn=WEB_IDENTITY_ROLE_ARN,
     )
@@ -506,7 +507,7 @@ def test_get_aws_security_credentials_from_webidentity_passed_in_one_param(
 
     with pytest.raises(SystemExit) as ex:
         mount_efs.get_aws_security_credentials(
-            config, True, "us-east-1", jwt_path=WEB_IDENTITY_TOKEN_FILE
+            config, True, "us-east-1", "amazonaws.com", jwt_path=WEB_IDENTITY_TOKEN_FILE
         )
 
     assert 0 != ex.value.code

--- a/test/mount_efs_test/test_get_dns_name_and_fallback_mount_target_ip_address.py
+++ b/test/mount_efs_test/test_get_dns_name_and_fallback_mount_target_ip_address.py
@@ -28,9 +28,14 @@ SPECIAL_REGION_DNS_DICT = {
     "cn-north-1": "amazonaws.com.cn",
     "cn-northwest-1": "amazonaws.com.cn",
     "us-iso-east-1": "c2s.ic.gov",
+    "us-iso-west-1": "c2s.ic.gov",
     "us-isob-east-1": "sc2s.sgov.gov",
+    "us-isob-west-1": "sc2s.sgov.gov",
+    "us-isof-south-1": "csp.hci.ic.gov",
+    "us-isof-east-1": "csp.hci.ic.gov",
+    "eu-isoe-west-1": "cloud.adc-e.uk"
 }
-SPECIAL_REGIONS = ["cn-north-1", "cn-northwest-1", "us-iso-east-1", "us-isob-east-1"]
+SPECIAL_REGIONS = ["cn-north-1", "cn-northwest-1", "us-iso-east-1", "us-iso-west-1", "us-isob-east-1", "us-isob-west-1", "us-isof-south-1", "us-isof-east-1", "eu-isoe-west-1"]
 DEFAULT_NFS_OPTIONS = {}
 OPTIONS_WITH_AZ = {"az": DEFAULT_AZ}
 OPTIONS_WITH_IP = {"mounttargetip": IP_ADDRESS}


### PR DESCRIPTION
*Issue #, if available:*
Addresses [STS_ENDPOINT_URL hardcoded dns name suffix](https://github.com/aws/efs-utils/issues/232)

*Description of changes:*
Added a helper function to pull region-specific domain name suffix strings from the `efs-utils.conf` file in order to allow authentication via webidentity to hit the proper STS endpoint for those regions. Modified `mount_efs` and `watchdog` scripts as well as added some missing regions and their domain suffixes to the `efs-utils.conf` file. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
