### PR TITLE
Add rpm-without-system-rust to rpmspec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ SOURCE_TARBALL = $(PACKAGE_NAME).tar.gz
 SPECFILE = $(PACKAGE_NAME).spec
 BUILD_DIR = build/rpmbuild
 PROXY_VERSION = 2.0.0
+RPM_BUILD_FLAGS ?= --with system_rust
 export PYTHONPATH := $(shell pwd)/src
 
 .PHONY: clean
@@ -48,11 +49,15 @@ rpm-only:
 	cp $(SPECFILE) $(BUILD_DIR)/SPECS
 	cp $(SOURCE_TARBALL) $(BUILD_DIR)/SOURCES
 	cp config.toml $(BUILD_DIR)/SOURCES
-	rpmbuild -ba --define "_topdir `pwd`/$(BUILD_DIR)" --define "include_vendor_tarball false" $(BUILD_DIR)/SPECS/$(SPECFILE)
+	rpmbuild -ba --define "_topdir `pwd`/$(BUILD_DIR)" --define "include_vendor_tarball false" $(BUILD_DIR)/SPECS/$(SPECFILE) $(RPM_BUILD_FLAGS)
 	cp $(BUILD_DIR)/RPMS/*/*rpm build
 
 .PHONY: rpm
 rpm: sources rpm-only
+
+.PHONY: rpm-without-system-rust
+rpm-without-system-rust: sources
+	$(MAKE) rpm-only RPM_BUILD_FLAGS="--without system_rust"
 
 .PHONY: deb
 deb:

--- a/amazon-efs-utils.spec
+++ b/amazon-efs-utils.spec
@@ -72,12 +72,14 @@ Requires(preun)  : /sbin/service /sbin/chkconfig
 Requires(postun) : /sbin/service
 %endif
 
-# RHEL 7 doesn't provide a Rust or Cargo package,
-# so users are expected to install it through rustup. 
-# The conditional here checks for amzn2 because on amzn2, 
-# '0%{?rhel}' also evaluates to 7.
-%if 0%{?amzn2} || 0%{?rhel} != 7
-BuildRequires  : cargo rust
+# Conditional to allow building without
+# rust installed with yum
+%bcond_without system_rust
+
+# If yum provides rust and cargo
+# use rpmbuild --with system_rust
+%if %{with system_rust}
+BuildRequires: cargo rust
 %endif
 
 BuildRequires: openssl-devel
@@ -94,6 +96,25 @@ This package provides utilities for simplifying the use of EFS file systems
 %global debug_package %{nil}
 
 %prep
+
+# If yum doesn't provides rust and cargo
+# use rpmbuild --without system_rust
+%if %{without system_rust}
+source $HOME/.cargo/env || true
+%endif
+
+# Ensure cargo is installed
+if ! command -v cargo &> /dev/null; then
+    echo "Error: cargo is not in PATH. Please install cargo."
+    exit 1
+fi
+
+# Ensure rustc is installed
+if ! command -v rustc &> /dev/null; then
+    echo "Error: rustc is not PATH. Please install rustc."
+    exit 1
+fi
+
 %setup -n %{name}
 mkdir -p %{_builddir}/%{name}/src/proxy/.cargo
 %if "%{include_vendor_tarball}" == "true"
@@ -176,17 +197,17 @@ fi
 
 * Tue Jun 18 2024 Arnav Gupta <arnavgup@amazon.com> - 2.0.3
 - Upgrade py version
-- Replace deprecated usage of datetime 
+- Replace deprecated usage of datetime
 
 * Mon May 20 2024 Anthony Tse <anthotse@amazon.com> - 2.0.2
 - Check for efs-proxy PIDs when cleaning tunnel state files
 - Add PID to log entries
 
 * Tue Apr 23 2024 Ryan Stankiewicz <rjstank@amazon.com> - 2.0.1
-- Disable Nagle's algorithm for efs-proxy TLS mounts to improve latencies 
+- Disable Nagle's algorithm for efs-proxy TLS mounts to improve latencies
 
 * Mon Apr 08 2024 Ryan Stankiewicz <rjstank@amazon.com> - 2.0.0
-- Replace stunnel, which provides TLS encryptions for mounts, with efs-proxy, a component built in-house at AWS. Efs-proxy lays the foundation for upcoming feature launches at EFS. 
+- Replace stunnel, which provides TLS encryptions for mounts, with efs-proxy, a component built in-house at AWS. Efs-proxy lays the foundation for upcoming feature launches at EFS.
 
 * Mon Mar 18 2024 Sean Zatz <zatzsea@amazon.com> - 1.36.0
 - Support new mount option: crossaccount, conduct cross account mounts via ip address. Use client AZ-ID to choose mount target.


### PR DESCRIPTION
Updated the rpmspec with the following conditions

 - with system_rust
 - without system_rust

[1] is the default and builds the rpmspec with
rustc and cargo provided they are installed
with yum

[2] builds the rpmspecfile with rustc and cargo
installed outside of yum (in cases where rustup
was used to install both rustc and cargo)

[1] and [2]  makes it possible to build both
instances using the Makefile.

The old makefile command

	make rpm

stays the same but assumes [1] and the new
command

	make rpm-without-system-rust

assumes [2]

*Issue #, if available:*
https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/1440

*Description of changes:*

The build in https://github.com/kubernetes-sigs/aws-efs-csi-driver fails because they use an image which installs rust using rustup.  Adding `make rpm-without-system-rust` will allow for such instances when there is the need to build 
with rust not installed by yum.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
