### PR TITLE
Update nix support for loongarch

### DIFF
--- a/src/proxy/Cargo.toml
+++ b/src/proxy/Cargo.toml
@@ -17,7 +17,7 @@ fern = "0.6"
 futures = "0.3"
 log = "0.4"
 log4rs = { version = "0", features = ["rolling_file_appender", "compound_policy", "size_trigger", "fixed_window_roller"]}
-nix = { version = "0.26.2", features = ["signal"]}
+nix = { version = "0.29.0", features = ["signal"]}
 onc-rpc = "0.2.3"
 rand = "0.8.5"
 s2n-tls = "0.0"


### PR DESCRIPTION
Description of changes:
LoongArch is an architecture similar to MIPS. The latest upstream tag of Nix now supports the LoongArch architecture. When I tried to build with nix=0.26.2, I encountered the error:

```c
error[E0432]: unresolved import `self::consts`
  --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nix-0.26.4/src/sys/ioctl/linux.rs:60:15
   |
60 | pub use self::consts::*;
   |               ^^^^^^ could not find `consts` in `self`
```
Upgrading to nix=0.29.0 resolves the issue.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
