### PR TITLE
Upgrade log4rs version to mitigate security vulnerabilities

### DIFF
--- a/src/proxy/Cargo.toml
+++ b/src/proxy/Cargo.toml
@@ -16,7 +16,7 @@ clap = { version = "=4.0.0", features = ["derive"] }
 fern = "0.6"
 futures = "0.3"
 log = "0.4"
-log4rs = { version = "0", features = ["rolling_file_appender", "compound_policy", "size_trigger", "fixed_window_roller"]}
+log4rs = { version = "1.2.0", features = ["rolling_file_appender", "compound_policy", "size_trigger", "fixed_window_roller"]}
 nix = { version = "0.26.2", features = ["signal"]}
 onc-rpc = "0.2.3"
 rand = "0.8.5"


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/efs-utils/issues/266

*Description of changes:*
There are two reported CVEs related to `traitobject` and `typemap`, both of which are transitive dependencies of `log4rs`. To mitigate these CVEs, we need to update `log4rs` to a version that does not depend on `typemap`. `log4rs` v1.2.0 depends on a different library (`typemap-ors`) and supports a minimum rust version of 1.56, so that's what we're upgrading to.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
