### PR TITLE
Remove RHEL 7 support from efs-utils README as its no longer supported.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ The `efs-utils` package has been verified against the following Linux distributi
 | Amazon Linux 2       | `rpm` | `systemd` |
 | Amazon Linux 2023    | `rpm` | `systemd` |
 | CentOS 8             | `rpm` | `systemd` |
-| RHEL 7               | `rpm` | `systemd` |
 | RHEL 8               | `rpm` | `systemd` |
 | RHEL 9               | `rpm` | `systemd` |
 | Fedora 29            | `rpm` | `systemd` |


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Remove RHEL 7 support from efs-utils README as its no longer supported.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
