### PR TITLE
Fix backtrace version to resolve ubuntu and rhel build issues

### DIFF
--- a/src/proxy/Cargo.toml
+++ b/src/proxy/Cargo.toml
@@ -30,6 +30,7 @@ tokio = { version = "1.29.0, <1.39", features = ["full"] }
 tokio-util = "0.7.8"
 uuid = { version = "1.4.1", features = ["v4", "fast-rng", "macro-diagnostics"]}
 xdr-codec = "0.4.4"
+backtrace = "=0.3.74"
 
 [dev-dependencies]
 test-case = "*"


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/efs-utils/issues/280

*Description of changes:*
Fixed backtrace version to a lower version in Cargo.toml to resolve rust version mismatch in Ubuntu and RHEL Images

*Testing*
Built `efs-utils` successfully using only the instruction in readme on following AMIs:
* Ubuntu 20
* Ubuntu 22
* Ubuntu 24
* RHEL 8
* RHEL 9

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
