### PR TITLE
Add stale issue/PR cleanup workflow

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,39 @@
+name: Close Stale Issues and PRs
+
+on:
+  schedule:
+    - cron: '0 14 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 60
+          days-before-close: 7
+          stale-issue-label: stale
+          stale-pr-label: stale
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not
+            had recent activity. It will be closed in 7 days if no further
+            activity occurs. If you believe this issue is still relevant, please
+            comment to keep it open.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it
+            has not had recent activity. It will be closed in 7 days if no
+            further activity occurs. If you believe this PR is still relevant,
+            please comment or push new changes to keep it open.
+          close-issue-message: >
+            This issue was closed because it has been stale for 7 days with no
+            activity. Feel free to reopen if this is still relevant.
+          close-pr-message: >
+            This pull request was closed because it has been stale for 7 days
+            with no activity. Feel free to reopen if this is still relevant.
+          exempt-issue-labels: pinned,security,bug
+          exempt-pr-labels: pinned,security


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow to automatically close stale issues and PRs
- Issues/PRs with no activity for 60 days are labeled `stale`, then closed after 7 more days of inactivity
- Runs daily at 10 AM ET; issues/PRs labeled `pinned`, `security`, or `bug` are exempt

## Motivation
Keeps the issue tracker clean by closing abandoned issues and PRs that are no longer relevant, while giving contributors a 7-day grace period to respond before closure.

## Test
- Tested on fork with 0-day thresholds and manual `workflow_dispatch` trigger
- Verified stale label is applied and close messages are posted
- https://github.com/DavidXU12345/efs-utils/issues/3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
