### PR TITLE
Add timeout to final mount.nfs4 fall-through attempt

### DIFF
--- a/src/efs_utils_common/mount_utils.py
+++ b/src/efs_utils_common/mount_utils.py
@@ -87,12 +87,35 @@ def mount_nfs(config, dns_name, path, mountpoint, options, fallback_ip_address=N
     ):
         return
 
-    logging.info('Executing: "%s"', " ".join(command))
+    final_attempt_timeout_sec = get_int_value_from_config_file(
+        config,
+        "retry_nfs_mount_command_timeout_sec",
+        DEFAULT_NFS_MOUNT_COMMAND_TIMEOUT_SEC,
+    )
+
+    logging.info(
+        'Executing: "%s" with %s sec time limit.'
+        % (" ".join(command), final_attempt_timeout_sec)
+    )
 
     proc = subprocess.Popen(
         command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, close_fds=True
     )
-    out, err = proc.communicate()
+    try:
+        out, err = proc.communicate(timeout=final_attempt_timeout_sec)
+    except subprocess.TimeoutExpired:
+        try:
+            proc.kill()
+        except OSError:
+            pass
+        proc.wait()
+        err = b"final mount attempt timed out after %d sec" % final_attempt_timeout_sec
+        message = 'Failed to mount %s at %s: %s' % (
+            dns_name,
+            mountpoint,
+            err.decode("utf-8", errors="replace"),
+        )
+        fatal_error(err.decode("utf-8", errors="replace"), message, 32)
 
     if proc.returncode == 0:
         post_mount_nfs_success(config, options, dns_name, mountpoint)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The fall-through final mount attempt in `mount_nfs()` calls `proc.communicate()` without a timeout. When the FSS data plane intermittently drops connections, the kernel `mount.nfs4` syscall with `hard,timeo=600,retrans=2` can block this final attempt for 5+ minutes before returning ETIMEDOUT.

This fix applies the same timeout (`retry_nfs_mount_command_timeout_sec`, default 15s) to the final attempt as is used in the bounded retry loop.

The retry loop at `call_nfs_mount_command_with_retry_succeed()` runs `retry_count - 1` bounded attempts. After they fail, the code falls through to an unbounded final attempt. With the default `retry_count=3`, worst-case mount time was previously unbounded; now it's `(retry_count - 1) * timeout + final_timeout` = ~45s by default.