### PR TITLE
efs-utils v3.1.2-1 release

### DIFF
--- a/CHANGELOG-3.x.md
+++ b/CHANGELOG-3.x.md
@@ -1,3 +1,8 @@
+# v3.1.2
+- Fix channel init deadline establishment
+- Update STS endpoint resolution
+- Add RHEL10 support to efs-utils
+
 # v3.1.1
 - Update proxy connection scaling logic
 - Fix IndexError in get_system_release_version on SUSE SLES 16

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -75,7 +75,7 @@ sudo yum -y install gcc13 gcc13-c++
 # For openSUSE Tumbleweed
 sudo zypper install -y gcc13 gcc13-c++
 
-# For Fedora 42 and RHEL 10, package manager does not provide GCC 13 or earlier
+# For Fedora 42, package manager does not provide GCC 13 or earlier
 # Follow offical GCC instruction to install desired version of GCC
 # https://gcc.gnu.org/install/
 
@@ -83,6 +83,19 @@ sudo zypper install -y gcc13 gcc13-c++
 export CC=gcc-13
 export CXX=g++-13
 # Then proceed with the normal build steps
+```
+
+**RHEL 10, use clang**
+
+```bash
+# Install clang
+sudo dnf install -y clang
+
+# Set clang as the compiler for the build
+export CC=clang
+export CXX=clang++
+export CFLAGS="-Wno-unused-command-line-argument"
+export CXXFLAGS="-Wno-unused-command-line-argument"
 ```
 
 **Ubuntu 20.04, upgrade to use gcc-10 and g++-10**

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Efs-utils for EFS and S3 file systems are supported on the following Linux distr
 | Amazon Linux 2023    | `rpm` | `systemd` |
 | RHEL 8               | `rpm` | `systemd` |
 | RHEL 9               | `rpm` | `systemd` |
+| RHEL 10              | `rpm` | `systemd` |
 | Ubuntu 20.04         | `deb` | `systemd` |
 | Ubuntu 22.04         | `deb` | `systemd` |
 | Ubuntu 24.04         | `deb` | `systemd` |

--- a/amazon-efs-utils.spec
+++ b/amazon-efs-utils.spec
@@ -41,7 +41,7 @@
 %{?!include_vendor_tarball:%define include_vendor_tarball true}
 
 Name      : amazon-efs-utils
-Version   : 3.1.1
+Version   : 3.1.2
 Release   : 1%{platform}
 Summary   : This package provides utilities for simplifying the use of EFS file systems
 
@@ -215,6 +215,11 @@ fi
 %clean
 
 %changelog
+* Tue Jun 2 2026 Michael Adams <admsam@amazon.com> - 3.1.2
+- Fix channel init deadline establishment
+- Update STS endpoint resolution
+- Add RHEL10 support to efs-utils
+
 * Mon Apr 27 2026 Zachary Maguire <maguirza@amazon.com> - 3.1.1
 - Update proxy connection scaling logic
 - Fix IndexError in get_system_release_version on SUSE SLES 16

--- a/build-deb.sh
+++ b/build-deb.sh
@@ -11,7 +11,7 @@ set -ex
 
 BASE_DIR=$(pwd)
 BUILD_ROOT=${BASE_DIR}/build/debbuild
-VERSION=3.1.1
+VERSION=3.1.2
 RELEASE=1
 ARCH=$(dpkg --print-architecture)
 DEB_SYSTEM_RELEASE_PATH=/etc/os-release

--- a/config.ini
+++ b/config.ini
@@ -7,5 +7,5 @@
 #
 
 [global]
-version=3.1.1
+version=3.1.2
 release=1

--- a/src/efs_utils_common/aws_credentials.py
+++ b/src/efs_utils_common/aws_credentials.py
@@ -308,6 +308,8 @@ def get_aws_security_credentials_from_pod_identity(config, is_fatal=False):
 
 def get_sts_endpoint_url(config, region):
     dns_name_suffix = get_dns_name_suffix(config, region)
+    if dns_name_suffix == "on.aws":
+        dns_name_suffix = "amazonaws.com"
     return STS_ENDPOINT_URL_FORMAT.format(region, dns_name_suffix)
 
 

--- a/src/efs_utils_common/constants.py
+++ b/src/efs_utils_common/constants.py
@@ -11,7 +11,7 @@ import os
 import pwd
 import re
 
-VERSION = "3.1.1"
+VERSION = "3.1.2"
 
 AMAZON_LINUX_2_RELEASE_ID = "Amazon Linux release 2 (Karoo)"
 AMAZON_LINUX_2_PRETTY_NAME = "Amazon Linux 2"

--- a/src/efs_utils_common/file_utils.py
+++ b/src/efs_utils_common/file_utils.py
@@ -80,3 +80,24 @@ def check_and_remove_lock_file(path, file):
             logging.debug(
                 "%s does not exist, The file is already removed nothing to do", path
             )
+
+
+def get_file_safe_mountpoint_name(mountpoint):
+    """Convert a mount path to a dot-separated, filename-safe string.
+
+    State files on disk use the mountpoint as part of their filename (e.g.
+    fs-deadbeef.mnt.efs.20407). Since filenames cannot contain '/', this
+    function replaces path separators with dots and strips the leading dots
+    that result from the root '/'.
+
+    Both proxy.py (at mount time) and the watchdog (at health-check time)
+    must produce the same string for a given mountpoint, otherwise the
+    watchdog cannot match state files to active mounts and will incorrectly
+    kill TLS tunnels. See https://github.com/aws/efs-utils/issues/218.
+
+    Examples:
+        /mnt/efs   -> mnt.efs
+        /.efs      -> efs
+        /          -> '' (empty string)
+    """
+    return os.path.abspath(mountpoint).replace(os.sep, ".").lstrip(".")

--- a/src/efs_utils_common/network_utils.py
+++ b/src/efs_utils_common/network_utils.py
@@ -80,7 +80,10 @@ def get_ipv6_addresses(hostname):
 
 def dns_name_can_be_resolved(dns_name):
     try:
-        addr_info = socket.getaddrinfo(dns_name, None, socket.AF_UNSPEC)
+        # Trailing dot forces absolute FQDN resolution, preventing the resolver
+        # from appending VPC search domains (e.g. .compute.internal).
+        fqdn = dns_name if dns_name.endswith(".") else dns_name + "."
+        addr_info = socket.getaddrinfo(fqdn, None, socket.AF_UNSPEC)
         return len(addr_info) > 0
     except socket.gaierror:
         return False

--- a/src/efs_utils_common/proxy.py
+++ b/src/efs_utils_common/proxy.py
@@ -54,7 +54,10 @@ from efs_utils_common.constants import (
 )
 from efs_utils_common.context import MountContext
 from efs_utils_common.error_reporting import fatal_error
-from efs_utils_common.file_utils import create_required_directory
+from efs_utils_common.file_utils import (
+    create_required_directory,
+    get_file_safe_mountpoint_name,
+)
 from efs_utils_common.metadata import (
     STUNNEL_EFS_CONFIG,
     STUNNEL_GLOBAL_CONFIG,
@@ -163,7 +166,7 @@ def find_existing_mount_using_tls_port(state_file_dir, tls_port):
 def get_mount_specific_filename(fs_id, mountpoint, tls_port):
     return "%s.%s.%d" % (
         fs_id,
-        os.path.abspath(mountpoint).replace(os.sep, ".").lstrip("."),
+        get_file_safe_mountpoint_name(mountpoint),
         tls_port,
     )
 

--- a/src/mount_s3files/dns_resolver.py
+++ b/src/mount_s3files/dns_resolver.py
@@ -142,7 +142,8 @@ def match_device(config, device, options):
         return remote, path, None
 
     try:
-        primary, secondaries, _ = socket.gethostbyname_ex(remote)
+        fqdn = remote if remote.endswith(".") else remote + "."
+        primary, secondaries, _ = socket.gethostbyname_ex(fqdn)
         hostnames = list(filter(lambda e: e is not None, [primary] + secondaries))
     except socket.gaierror:
         create_default_cloudwatchlog_agent_if_not_exist(config, options)

--- a/src/proxy/Cargo.lock
+++ b/src/proxy/Cargo.lock
@@ -23,7 +23,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
- "memchr 2.8.0",
+ "memchr 2.8.1",
 ]
 
 [[package]]
@@ -116,15 +116,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
-version = "1.8.16"
+version = "1.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f156acdd2cf55f5aa53ee416c4ac851cf1222694506c0b1f78c85695e9ca9d"
+checksum = "e33f815b73a3899c03b380d543532e5865f230dce9678d108dc10732a8682275"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -136,12 +136,13 @@ dependencies = [
  "aws-smithy-json",
  "aws-smithy-runtime",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "aws-types",
  "bytes",
  "fastrand",
  "hex",
- "http 1.4.0",
+ "http 1.4.1",
  "sha1 0.10.6",
  "time",
  "tokio",
@@ -178,9 +179,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-fips-sys",
  "aws-lc-sys",
@@ -190,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -202,9 +203,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.7.3"
+version = "1.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
+checksum = "77ed8e8c52d2dc2390ad9f15647fe663f71e9780b4262c190fbb823a32721566"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -219,7 +220,7 @@ dependencies = [
  "bytes-utils",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "percent-encoding",
@@ -230,10 +231,11 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudwatch"
-version = "1.110.0"
+version = "1.114.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd42d00863c342bcfedfc4f38845103f5b06b01b3b5024c02fa5aeafbb1195a5"
+checksum = "e59ad7f2a653777562a9e9b9f8eee18e38099e172c5a82e5c3304250c3f850e4"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -249,7 +251,7 @@ dependencies = [
  "fastrand",
  "flate2",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "regex-lite",
@@ -258,10 +260,11 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudwatchlogs"
-version = "1.129.0"
+version = "1.135.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba73166148f1036fb3f512e4f05a025ab3338469cc97fa87684978526d6d728a"
+checksum = "7c0634c5c3b14a8d5381acd4b45240ea114e8bb4aa7953beb539289f7e77246c"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -276,17 +279,18 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.131.0"
+version = "1.135.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe1b8c5282bf859170836045296b3cd710b7573aceb909498366bb508a41058e"
+checksum = "f97e3e7e7d86fd26fcdc18bc382da5ca9e8b2ff8d54030d187fd0dac8a236d96"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-sigv4",
@@ -306,7 +310,7 @@ dependencies = [
  "hex",
  "hmac 0.13.0",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "lru",
  "percent-encoding",
@@ -318,10 +322,11 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.98.0"
+version = "1.101.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d69c77aafa20460c68b6b3213c84f6423b6e76dbf89accd3e1789a686ffd9489"
+checksum = "b647baea49ff551960b904f905681e9b4765a6c4ea08631e89dc52d8bd3f5896"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -335,17 +340,18 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.100.0"
+version = "1.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7e7b09346d5ca22a2a08267555843a6a0127fb20d8964cb6ecfb8fdb190225"
+checksum = "7ae401c65ff288aa7873117fe535cd32b7b1bb0bc43751d28901a1d5f20636b9"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -359,17 +365,18 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.103.0"
+version = "1.106.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2249b81a2e73a8027c41c378463a81ec39b8510f184f2caab87de912af0f49b"
+checksum = "4c80de7bb7d03e9ca8c9fd7b489f20f3948d3f3be91a7953591347d238115408"
 dependencies = [
+ "arc-swap",
  "aws-credential-types",
  "aws-runtime",
  "aws-smithy-async",
@@ -384,16 +391,16 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "regex-lite",
  "tracing",
 ]
 
 [[package]]
 name = "aws-sigv4"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
+checksum = "bae38512beae0ffee7010fc24e7a8a123c53efdfef42a61e80fda4882418dc71"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -401,15 +408,14 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "crypto-bigint 0.5.5",
+ "crypto-bigint",
  "form_urlencoded",
  "hex",
  "hmac 0.13.0",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "p256",
  "percent-encoding",
- "ring",
  "sha2 0.11.0",
  "subtle",
  "time",
@@ -430,26 +436,28 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-cbor"
-version = "0.61.7"
+version = "0.61.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "448f0ebde2b5dc9775055e5260dbf83a981e45891905b9b93d577e5886ae8519"
+checksum = "91f8768bf5156b97fc3111e7b63b528c1b022eb7edb20a5d0b77e7c2c1d5f24b"
 dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "minicbor",
 ]
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.64.7"
+version = "0.64.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10efbbcec1e044b81600e2fc562a391951d291152d95b482d5b7e7132299d762"
+checksum = "e9e8e65f4f81fcccdeb6c3eca2af17ac21d421a1786a26a394aecf421d616d3a"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
  "bytes",
  "crc-fast",
  "hex",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "md-5",
@@ -470,7 +478,7 @@ dependencies = [
  "bytes",
  "flate2",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
@@ -501,7 +509,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "percent-encoding",
@@ -512,9 +520,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+checksum = "5c3ef8931ad1c98aa6a55b4256f847f3116090819844e0dd41ea682cac5dd2d3"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-protocol-test",
@@ -522,13 +530,13 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "h2 0.3.27",
- "h2 0.4.13",
+ "h2 0.4.14",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "hyper 0.14.32",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-rustls 0.24.2",
  "hyper-rustls 0.27.9",
  "hyper-util",
@@ -548,10 +556,12 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-json"
-version = "0.62.5"
+version = "0.62.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+checksum = "701a947f4797e52a911e114a898667c746c39feea467bbd1abd7b3721f702ffa"
 dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
 ]
 
@@ -564,7 +574,7 @@ dependencies = [
  "aws-smithy-http-client",
  "aws-smithy-runtime-api",
  "aws-smithy-types",
- "http 1.4.0",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -607,20 +617,21 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.11.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
+checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
  "aws-smithy-http-client",
  "aws-smithy-observability",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -633,16 +644,16 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.12.0"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
+checksum = "9db177daa6ba8afb9ee1aefcf548c907abcf52065e394ee11a92780057fe0e8c"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -661,17 +672,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "aws-smithy-types"
-version = "1.4.7"
+name = "aws-smithy-schema"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.1",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53f93074121a1be41317b9aa607143ae17900631f7f59a99f2b905d519d6783b"
 dependencies = [
  "base64-simd",
  "bytes",
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -697,13 +719,14 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.15"
+version = "1.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
+checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
  "aws-smithy-runtime-api",
+ "aws-smithy-schema",
  "aws-smithy-types",
  "rustc_version",
  "tracing",
@@ -726,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "base16ct"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -758,17 +781,17 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
- "log 0.4.29",
+ "log 0.4.32",
  "prettyplease",
  "proc-macro2",
  "quote 1.0.45",
  "regex",
  "rustc-hash",
- "shlex",
+ "shlex 1.3.0",
  "syn 2.0.117",
 ]
 
@@ -786,9 +809,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
 
 [[package]]
 name = "block-buffer"
@@ -819,9 +842,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -866,14 +889,14 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
- "shlex",
+ "shlex 2.0.1",
 ]
 
 [[package]]
@@ -904,9 +927,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1016,9 +1039,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "const-oid"
@@ -1067,29 +1090,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
-
-[[package]]
 name = "crc-fast"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
 dependencies = [
- "crc",
  "digest 0.10.7",
- "rustversion",
  "spin",
 ]
 
@@ -1144,24 +1150,14 @@ checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-bigint"
-version = "0.4.9"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -1176,9 +1172,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
@@ -1194,9 +1190,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1214,11 +1210,12 @@ checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
-version = "0.6.1"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1278,27 +1275,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -1325,19 +1323,21 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
-version = "0.14.8"
+version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
+ "spki",
 ]
 
 [[package]]
 name = "efs-proxy"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1360,7 +1360,7 @@ dependencies = [
  "hex-literal",
  "hyper 0.14.32",
  "libc",
- "log 0.4.29",
+ "log 0.4.32",
  "log4rs",
  "lru",
  "mockall",
@@ -1390,23 +1390,23 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.12.3"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
- "crypto-bigint 0.4.9",
- "der",
+ "crypto-bigint",
  "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
+ "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
  "sec1",
@@ -1422,7 +1422,7 @@ checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
 dependencies = [
  "humantime",
  "is-terminal",
- "log 0.4.29",
+ "log 0.4.32",
  "regex",
  "termcolor",
 ]
@@ -1460,9 +1460,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "ff"
-version = "0.12.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
  "rand_core 0.6.4",
  "subtle",
@@ -1618,7 +1618,7 @@ dependencies = [
  "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr 2.8.0",
+ "memchr 2.8.1",
  "pin-project-lite",
  "slab",
 ]
@@ -1631,6 +1631,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1684,9 +1685,9 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "group"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
  "rand_core 0.6.4",
@@ -1714,16 +1715,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.4.1",
  "indexmap",
  "slab",
  "tokio",
@@ -1770,9 +1771,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -1828,7 +1829,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1844,9 +1845,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1870,7 +1871,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -1881,7 +1882,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -1906,9 +1907,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -1939,16 +1940,16 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
+ "h2 0.4.14",
+ "http 1.4.1",
  "http-body 1.0.1",
  "httparse",
  "itoa",
@@ -1967,7 +1968,7 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "hyper 0.14.32",
- "log 0.4.29",
+ "log 0.4.32",
  "rustls 0.21.12",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -1979,8 +1980,8 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
- "hyper 1.9.0",
+ "http 1.4.1",
+ "hyper 1.10.1",
  "hyper-util",
  "rustls 0.23.40",
  "rustls-native-certs",
@@ -1999,14 +2000,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -2022,7 +2023,7 @@ dependencies = [
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
- "log 0.4.29",
+ "log 0.4.32",
  "wasm-bindgen",
  "windows-core 0.62.2",
 ]
@@ -2152,7 +2153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2210,9 +2211,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2281,14 +2282,14 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 dependencies = [
- "log 0.4.29",
+ "log 0.4.32",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 dependencies = [
  "serde_core",
 ]
@@ -2312,7 +2313,7 @@ dependencies = [
  "fnv",
  "humantime",
  "libc",
- "log 0.4.29",
+ "log 0.4.32",
  "log-mdc",
  "mock_instant",
  "parking_lot",
@@ -2353,7 +2354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2367,9 +2368,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "memoffset"
@@ -2382,23 +2383,11 @@ dependencies = [
 
 [[package]]
 name = "minicbor"
-version = "0.24.4"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29be4f60e41fde478b36998b88821946aafac540e53591e76db53921a0cc225b"
+checksum = "1b7a5041e12946f8b7d3f5a9d96383a19d694b9335457c522be7815b9abafb02"
 dependencies = [
  "half",
- "minicbor-derive",
-]
-
-[[package]]
-name = "minicbor-derive"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd2209fff77f705b00c737016a48e73733d7fbccb8b007194db148f03561fb70"
-dependencies = [
- "proc-macro2",
- "quote 1.0.45",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -2419,9 +2408,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -2506,7 +2495,7 @@ version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
- "memchr 2.8.0",
+ "memchr 2.8.1",
  "minimal-lexical",
 ]
 
@@ -2546,9 +2535,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2585,7 +2574,7 @@ version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
- "memchr 2.8.0",
+ "memchr 2.8.1",
 ]
 
 [[package]]
@@ -2634,12 +2623,13 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
-version = "0.11.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
  "ecdsa",
  "elliptic-curve",
+ "primeorder",
  "sha2 0.10.9",
 ]
 
@@ -2667,6 +2657,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2686,9 +2685,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs8"
-version = "0.9.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
  "der",
  "spki",
@@ -2772,6 +2771,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -2936,7 +2944,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
 ]
 
 [[package]]
@@ -2946,7 +2954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
- "memchr 2.8.0",
+ "memchr 2.8.1",
  "regex-automata",
  "regex-syntax",
 ]
@@ -2958,7 +2966,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
- "memchr 2.8.0",
+ "memchr 2.8.1",
  "regex-syntax",
 ]
 
@@ -2982,13 +2990,12 @@ checksum = "194d8e591e405d1eecf28819740abed6d719d1a2db87fc0bcdedee9a26d55560"
 
 [[package]]
 name = "rfc6979"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "crypto-bigint 0.4.9",
  "hmac 0.12.1",
- "zeroize",
+ "subtle",
 ]
 
 [[package]]
@@ -3041,7 +3048,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3054,7 +3061,7 @@ version = "0.21.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
 dependencies = [
- "log 0.4.29",
+ "log 0.4.32",
  "ring",
  "rustls-webpki 0.101.7",
  "sct",
@@ -3076,9 +3083,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -3131,9 +3138,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "s2n-tls"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d22c36f207d0bb6a38272d5d1fa1cd99094335c70db1bfef54e0b8b672ae26f"
+checksum = "f60ada8adc59c848686744ff0ca93f1d1edc565a69d96a58a26abd84a521a5a0"
 dependencies = [
  "errno",
  "hex",
@@ -3144,9 +3151,9 @@ dependencies = [
 
 [[package]]
 name = "s2n-tls-sys"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf9e3b136cdd2c99f0cee2811d80b9f6bc44b5fd48c172857de32babb506f5e"
+checksum = "e6960ccb00e47fe4b641f9c7b769515a4f89cb65459ca7afbed20fa39aac0b1b"
 dependencies = [
  "aws-lc-rs",
  "cc",
@@ -3155,24 +3162,15 @@ dependencies = [
 
 [[package]]
 name = "s2n-tls-tokio"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e0ab00b075ab482e89509de51e1972a8f38ff70e1dbd5279caa0fd8d25f86cb"
+checksum = "fdeee0425e44094040f5c3a065a6e42974e9bc1a7587a292f520715b0f9fbbd5"
 dependencies = [
  "errno",
  "libc",
  "pin-project-lite",
  "s2n-tls",
  "tokio",
-]
-
-[[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
 ]
 
 [[package]]
@@ -3201,16 +3199,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
-
-[[package]]
 name = "sec1"
-version = "0.3.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
@@ -3226,7 +3218,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3308,13 +3300,13 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap",
  "itoa",
- "memchr 2.8.0",
+ "memchr 2.8.1",
  "serde",
  "serde_core",
  "zmij",
@@ -3335,24 +3327,23 @@ dependencies = [
 
 [[package]]
 name = "serial_test"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
 dependencies = [
  "futures-executor",
  "futures-util",
- "log 0.4.29",
+ "log 0.4.32",
  "once_cell",
  "parking_lot",
- "scc",
  "serial_test_derive",
 ]
 
 [[package]]
 name = "serial_test_derive"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -3378,7 +3369,7 @@ checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3400,7 +3391,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3419,6 +3410,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3430,9 +3427,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.6.4"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
@@ -3468,9 +3465,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -3484,9 +3481,9 @@ checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 
 [[package]]
 name = "spki"
-version = "0.6.0"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
@@ -3575,7 +3572,7 @@ checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
 dependencies = [
  "core-foundation-sys",
  "libc",
- "memchr 2.8.0",
+ "memchr 2.8.1",
  "ntapi",
  "rayon",
  "windows",
@@ -3793,9 +3790,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -3803,7 +3800,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3912,7 +3909,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "log 0.4.29",
+ "log 0.4.32",
  "once_cell",
  "tracing-core",
 ]
@@ -3965,9 +3962,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -3977,9 +3974,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -4046,9 +4043,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -4121,9 +4118,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4134,9 +4131,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote 1.0.45",
  "wasm-bindgen-macro-support",
@@ -4144,9 +4141,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4157,9 +4154,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -4192,7 +4189,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -4487,9 +4484,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.12.1",
  "indexmap",
- "log 0.4.29",
+ "log 0.4.32",
  "serde",
  "serde_derive",
  "serde_json",
@@ -4508,7 +4505,7 @@ dependencies = [
  "anyhow",
  "id-arena",
  "indexmap",
- "log 0.4.29",
+ "log 0.4.32",
  "semver",
  "serde",
  "serde_derive",
@@ -4559,9 +4556,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4582,18 +4579,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote 1.0.45",
@@ -4602,9 +4599,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/src/proxy/Cargo.toml
+++ b/src/proxy/Cargo.toml
@@ -3,7 +3,7 @@ name = "efs-proxy"
 edition = "2021"
 build = "build.rs"
 # The version of efs-proxy is tied to efs-utils.
-version = "3.1.1"
+version = "3.1.2"
 publish = false
 license = "MIT"
 

--- a/src/proxy/src/controller.rs
+++ b/src/proxy/src/controller.rs
@@ -137,16 +137,6 @@ impl<S: ProxyStream> Controller<S> {
         let mut ready_connections = None;
         // Main Proxy incarnation management loop
         loop {
-            // Set init_deadline to be 1 second less than the `proxy_init_timeout_sec`, as we
-            // expect this proxy to be killed if the initial NFS mount did not succeed when the full
-            // `proxy_init_timeout_sec` has elapsed.
-            let init_deadline = create_deadline(Duration::from_secs(
-                self.proxy_config
-                    .nested_config
-                    .proxy_init_timeout_sec
-                    .saturating_sub(1),
-            ));
-
             info!("Starting new incarnation of proxy");
             let nfs_client = match self.listener.accept().await {
                 Ok((client, socket_addr)) => {
@@ -175,6 +165,18 @@ impl<S: ProxyStream> Controller<S> {
                 error!("Failed to check if data was sent by the NFS client. {}", e);
                 return Some(ShutdownReason::UnexpectedError);
             }
+
+            // Set init_deadline to be 1 second less than the `proxy_init_timeout_sec`, as we
+            // expect this proxy to be killed if the initial NFS mount did not succeed when the full
+            // `proxy_init_timeout_sec` has elapsed.
+            // Set after accept so the timeout budget is not consumed by time spent waiting for
+            // the NFS client to reconnect.
+            let init_deadline = create_deadline(Duration::from_secs(
+                self.proxy_config
+                    .nested_config
+                    .proxy_init_timeout_sec
+                    .saturating_sub(1),
+            ));
 
             // Create Status Notifications channel, to be used by Proxy's status_reporter for notifying controller about Proxy status
             let (status_events_tx, mut status_events_rx) = mpsc::channel(1024);
@@ -215,11 +217,11 @@ impl<S: ProxyStream> Controller<S> {
                 None => debug!("Established initial connection without a PartitionId"),
             }
 
-            let mut configs = Vec::new();
-
-            // Add read bypass config if requested
-            if self.proxy_config.nested_config.read_bypass_config.requested {
-                configs.push(ChannelConfigArgs::AWSFILE_READ_BYPASS_V2(
+            // Skip channel init if read bypass is not requested
+            let channel_init_config = if !self.proxy_config.nested_config.read_bypass_config.requested {
+                ChannelInitConfig::default()
+            } else {
+                let configs = vec![ChannelConfigArgs::AWSFILE_READ_BYPASS_V2(
                     AwsFileReadBypassConfigArgsV2 {
                         enabled: self.proxy_config.nested_config.read_bypass_config.enabled,
                         efs_utils_version: self
@@ -229,36 +231,36 @@ impl<S: ProxyStream> Controller<S> {
                             .as_bytes()
                             .to_vec(),
                     },
-                ));
-            }
+                )];
 
-            let channel_init_args = AwsFileChannelInitArgs {
-                minor_version: AWSFILE_CHANNEL_INIT_MINOR_VERSION,
-                configs,
-            };
+                let channel_init_args = AwsFileChannelInitArgs {
+                    minor_version: AWSFILE_CHANNEL_INIT_MINOR_VERSION,
+                    configs,
+                };
 
-            let channel_init_config = match rpc_client
-                .channel_init(
-                    init_deadline,
-                    &channel_init_args,
-                    partition_servers
-                        .get_mut(0)
-                        .expect("No awsfile server connections exist"),
-                )
-                .await
-            {
-                Ok(config) => {
-                    debug!("ChannelInitConfig: {:#?}", config);
-                    config
-                }
-                Err(e) => {
-                    warn!("{e}");
-                    if used_reused_connections && matches!(&e, RpcError::ChannelInitTimeout) {
-                        warn!("channel_init timed out on reused connections, restarting with fresh connections");
-                        ready_connections = None;
-                        continue;
+                match rpc_client
+                    .channel_init(
+                        init_deadline,
+                        &channel_init_args,
+                        partition_servers
+                            .get_mut(0)
+                            .expect("No awsfile server connections exist"),
+                    )
+                    .await
+                {
+                    Ok(config) => {
+                        debug!("ChannelInitConfig: {:#?}", config);
+                        config
                     }
-                    ChannelInitConfig::default()
+                    Err(e) => {
+                        warn!("{e}");
+                        if used_reused_connections && matches!(&e, RpcError::ChannelInitTimeout) {
+                            warn!("channel_init timed out on reused connections, restarting with fresh connections");
+                            ready_connections = None;
+                            continue;
+                        }
+                        ChannelInitConfig::default()
+                    }
                 }
             };
 

--- a/src/proxy/src/nfs/nfs_reader.rs
+++ b/src/proxy/src/nfs/nfs_reader.rs
@@ -180,6 +180,8 @@ mod tests {
     use tokio::sync::mpsc::error::SendError;
     use tokio_util::sync::CancellationToken;
 
+    /// Mock dispatcher that always returns SendError to simulate
+    /// a dropped connection (receiver side of channel gone).
     #[derive(Clone)]
     struct FailingDispatcher;
 
@@ -200,6 +202,10 @@ mod tests {
         }
     }
 
+    /// When the dispatcher channel is dropped (SendError), the
+    /// nfs_reader should signal NeedsRestart, not UnexpectedError.
+    /// This ensures the proxy restarts instead of exiting on
+    /// transient connection loss (e.g., load shedding RST).
     #[tokio::test]
     async fn test_dispatch_send_error_triggers_needs_restart() {
         let mut reader = NfsClientReader {

--- a/src/proxy/src/nfs/nfs_sniffer_dispatchers.rs
+++ b/src/proxy/src/nfs/nfs_sniffer_dispatchers.rs
@@ -59,7 +59,6 @@ pub struct NfsSnifferServerDispatcher {
 #[async_trait]
 impl Dispatcher<NfsRpcInfo, NfsServerDispatcherError> for NfsSnifferServerDispatcher {
     async fn dispatch(&mut self, message: NfsRpcInfo) -> Result<(), NfsServerDispatcherError> {
-
         let rpc_batch: RpcBatch = message.into();
 
         return self

--- a/src/proxy/src/read_bypass/read_bypass_agent.rs
+++ b/src/proxy/src/read_bypass/read_bypass_agent.rs
@@ -330,6 +330,7 @@ impl ReadBypassAgent {
             .expect("ReadBypassAgent is expecting to have one compound in the batch!");
 
         if let RefNfsCompound::Compound4res(compound_info) = &mut envelope.body {
+            // Full buffer clone to avoid uncontrolled memory consumption growth
             match Self::process_compound(
                 read_bypass_request_context.clone(),
                 &compound_info,

--- a/src/proxy/src/rpc/rpc_envelope.rs
+++ b/src/proxy/src/rpc/rpc_envelope.rs
@@ -200,6 +200,8 @@ pub trait Envelope<T> {
                         // Match the nested ReplyData enum
                         match accepted_reply.status() {
                             AcceptedStatus::Success(results) => results,
+                            // If it's not a success, return an empty slice (to be passed through)
+                            // parsing path.
                             _ => &[],
                         }
                     }

--- a/src/proxy/src/utils.rs
+++ b/src/proxy/src/utils.rs
@@ -42,6 +42,7 @@ pub fn has_sufficient_memory_for_readahead_cache() -> bool {
 
 /// Ensures HOME environment variable is set by resolving it from /etc/passwd if missing.
 /// The AWS SDK needs HOME to resolve ~/.aws/credentials for profile-based credential loading.
+/// This matches the mount helper's approach of using getpwuid for home dir resolution.
 pub fn ensure_home_env_set() {
     if std::env::var("HOME").is_err() {
         let uid = unsafe { libc::getuid() };

--- a/src/watchdog/__init__.py
+++ b/src/watchdog/__init__.py
@@ -56,7 +56,7 @@ AMAZON_LINUX_2_RELEASE_VERSIONS = [
     AMAZON_LINUX_2_RELEASE_ID,
     AMAZON_LINUX_2_PRETTY_NAME,
 ]
-VERSION = "3.1.1"
+VERSION = "3.1.2"
 SERVICE = "elasticfilesystem"
 FS_PREFIX = "fs-"
 
@@ -482,6 +482,8 @@ def get_aws_security_credentials_from_webidentity(config, role_arn, token_file, 
 
 def get_sts_endpoint_url(config, region):
     dns_name_suffix = get_dns_name_suffix(config, region)
+    if dns_name_suffix == "on.aws":
+        dns_name_suffix = "amazonaws.com"
     return STS_ENDPOINT_URL_FORMAT.format(region, dns_name_suffix)
 
 
@@ -712,10 +714,18 @@ def parse_options(options):
     return opts
 
 
+def get_file_safe_mountpoint_name(mountpoint):
+    """Convert a mount path to a dot-separated, filename-safe string.
+
+    This is a local copy of efs_utils_common.file_utils.get_file_safe_mountpoint_name().
+    The watchdog cannot import from efs_utils_common due to its install location.
+    Both copies must stay in sync — see https://github.com/aws/efs-utils/issues/218.
+    """
+    return os.path.abspath(mountpoint).replace(os.sep, ".").lstrip(".")
+
+
 def get_file_safe_mountpoint(mount):
-    mountpoint = os.path.abspath(mount.mountpoint).replace(os.sep, ".")
-    if mountpoint.startswith("."):
-        mountpoint = mountpoint[1:]
+    mountpoint = get_file_safe_mountpoint_name(mount.mountpoint)
 
     opts = parse_options(mount.options)
     if "port" not in opts:

--- a/test/mount_common_test/test_get_file_safe_mountpoint_name.py
+++ b/test/mount_common_test/test_get_file_safe_mountpoint_name.py
@@ -1,0 +1,43 @@
+#
+# Copyright 2017-2018 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the MIT License. See the LICENSE accompanying this file
+# for the specific language governing permissions and limitations under
+# the License.
+#
+
+from efs_utils_common.file_utils import get_file_safe_mountpoint_name
+
+
+def test_standard_path():
+    assert "mnt" == get_file_safe_mountpoint_name("/mnt")
+
+
+def test_nested_path():
+    assert "mnt.efs.data" == get_file_safe_mountpoint_name("/mnt/efs/data")
+
+
+def test_root_path():
+    """/ -> . -> '' (empty string)"""
+    assert "" == get_file_safe_mountpoint_name("/")
+
+
+def test_hidden_directory():
+    """/.efs -> ..efs -> efs (the bug-fix case from GitHub issue #218)"""
+    assert "efs" == get_file_safe_mountpoint_name("/.efs")
+
+
+def test_hidden_directory_nested():
+    assert "hidden.data" == get_file_safe_mountpoint_name("/.hidden/data")
+
+
+def test_hidden_directory_multiple_leading_dots():
+    """/...efs -> ....efs -> efs"""
+    assert "efs" == get_file_safe_mountpoint_name("/...efs")
+
+
+def test_mid_path_dot_preserved():
+    """Only leading dots are stripped, not dots in the middle of the path."""
+    assert "hidden..secret.data" == get_file_safe_mountpoint_name(
+        "/.hidden/.secret/data"
+    )

--- a/test/mount_efs_test/test_get_dns_name_and_fallback_mount_target_ip_address.py
+++ b/test/mount_efs_test/test_get_dns_name_and_fallback_mount_target_ip_address.py
@@ -326,7 +326,7 @@ def test_dns_name_can_be_resolved_dns_resolve_failure(mocker):
     dns_mock = mocker.patch("socket.getaddrinfo", side_effect=socket.gaierror)
     result = network_utils.dns_name_can_be_resolved(DNS_NAME)
     assert not result
-    utils.assert_called(dns_mock)
+    dns_mock.assert_called_once_with(DNS_NAME + ".", None, socket.AF_UNSPEC)
 
 
 def test_dns_name_can_be_resolved_dns_resolve_succeed():

--- a/test/watchdog_test/test_get_file_safe_mountpoint.py
+++ b/test/watchdog_test/test_get_file_safe_mountpoint.py
@@ -1,0 +1,139 @@
+#
+# Copyright 2017-2018 Amazon.com, Inc. and its affiliates. All Rights Reserved.
+#
+# Licensed under the MIT License. See the LICENSE accompanying this file
+# for the specific language governing permissions and limitations under
+# the License.
+#
+
+import watchdog
+
+DEFAULT_OPTIONS = "rw,port=12345"
+NO_PORT_OPTIONS = "rw,noresvport"
+
+
+def _mount(mountpoint, options=DEFAULT_OPTIONS):
+    """Build a Mount namedtuple with localhost defaults for concise test setup."""
+    return watchdog.Mount(
+        server="127.0.0.1:/",
+        mountpoint=mountpoint,
+        type="nfs4",
+        options=options,
+        freq="0",
+        passno="0",
+    )
+
+
+# --- Standard mount paths (regression tests) ---
+# These verify that the lstrip(".") change doesn't alter behavior for normal
+# (non-dot-prefixed) paths, where the old [1:] and new lstrip produce the same result.
+
+
+def test_standard_mount(mocker):
+    """/mnt -> .mnt -> mnt -> mnt.12345"""
+    mocker.patch("watchdog.check_if_running_on_macos", return_value=False)
+    assert "mnt.12345" == watchdog.get_file_safe_mountpoint(_mount("/mnt"))
+
+
+def test_nested_mount(mocker):
+    """/mnt/efs/data -> .mnt.efs.data -> mnt.efs.data -> mnt.efs.data.12345"""
+    mocker.patch("watchdog.check_if_running_on_macos", return_value=False)
+    assert "mnt.efs.data.12345" == watchdog.get_file_safe_mountpoint(
+        _mount("/mnt/efs/data")
+    )
+
+
+def test_root_mount(mocker):
+    """/ -> . -> '' (empty after lstrip) -> .12345
+    Edge case: nobody mounts EFS at root, but confirms behavior matches proxy.py."""
+    mocker.patch("watchdog.check_if_running_on_macos", return_value=False)
+    assert ".12345" == watchdog.get_file_safe_mountpoint(_mount("/"))
+
+
+# --- Hidden directory (leading dot) mount paths ---
+# These are the bug-fix cases. The old code used mountpoint[1:] which only stripped
+# one character, leaving a residual dot from the directory name. The fix uses
+# lstrip(".") to strip all leading dots, matching proxy.py's get_mount_specific_filename().
+
+
+def test_hidden_directory_mount(mocker):
+    """/.efs -> ..efs -> efs -> efs.12345
+    The exact case from GitHub issue #218. Old code produced .efs.12345, causing
+    the watchdog to fail to match the state file and kill the TLS tunnel."""
+    mocker.patch("watchdog.check_if_running_on_macos", return_value=False)
+    assert "efs.12345" == watchdog.get_file_safe_mountpoint(_mount("/.efs"))
+
+
+def test_hidden_directory_nested_mount(mocker):
+    """/.hidden/data -> ..hidden.data -> hidden.data -> hidden.data.12345
+    Hidden first component with a normal child directory."""
+    mocker.patch("watchdog.check_if_running_on_macos", return_value=False)
+    assert "hidden.data.12345" == watchdog.get_file_safe_mountpoint(
+        _mount("/.hidden/data")
+    )
+
+
+def test_hidden_directory_deep_nested_mount(mocker):
+    """/.hidden/.secret/data -> ..hidden..secret.data -> hidden..secret.data.12345
+    The mid-path dot in .secret is NOT stripped — lstrip only affects leading dots.
+    This confirms we don't accidentally mangle dots in the middle of the path."""
+    mocker.patch("watchdog.check_if_running_on_macos", return_value=False)
+    assert "hidden..secret.data.12345" == watchdog.get_file_safe_mountpoint(
+        _mount("/.hidden/.secret/data")
+    )
+
+
+def test_hidden_directory_only_dots(mocker):
+    """/...efs -> ....efs -> efs -> efs.12345
+    Directory name with multiple leading dots. Confirms lstrip handles consecutive dots.
+    """
+    mocker.patch("watchdog.check_if_running_on_macos", return_value=False)
+    assert "efs.12345" == watchdog.get_file_safe_mountpoint(_mount("/...efs"))
+
+
+# --- Default NFS port (no port in mount options) ---
+# When port is missing from options on Linux, the function falls back to DEFAULT_NFS_PORT (2049).
+
+
+def test_no_port_uses_default_nfs_port(mocker):
+    mocker.patch("watchdog.check_if_running_on_macos", return_value=False)
+    assert "mnt.2049" == watchdog.get_file_safe_mountpoint(
+        _mount("/mnt", NO_PORT_OPTIONS)
+    )
+
+
+def test_hidden_directory_no_port_uses_default_nfs_port(mocker):
+    """Combines the dot-stripping fix with the default port fallback path."""
+    mocker.patch("watchdog.check_if_running_on_macos", return_value=False)
+    assert "efs.2049" == watchdog.get_file_safe_mountpoint(
+        _mount("/.efs", NO_PORT_OPTIONS)
+    )
+
+
+# --- macOS behavior ---
+# macOS uses nfsstat instead of /proc/mounts. When port is missing on macOS,
+# the function returns just the mountpoint without a port suffix (rather than
+# falling back to 2049 like Linux).
+
+
+def test_macos_with_port(mocker):
+    mocker.patch("watchdog.check_if_running_on_macos", return_value=True)
+    assert "mnt.12345" == watchdog.get_file_safe_mountpoint(_mount("/mnt"))
+
+
+def test_macos_no_port_returns_mountpoint_only(mocker):
+    """On macOS, missing port returns mountpoint without port suffix."""
+    mocker.patch("watchdog.check_if_running_on_macos", return_value=True)
+    assert "mnt" == watchdog.get_file_safe_mountpoint(_mount("/mnt", NO_PORT_OPTIONS))
+
+
+def test_macos_hidden_directory_with_port(mocker):
+    """Confirms the dot-stripping fix works on macOS too."""
+    mocker.patch("watchdog.check_if_running_on_macos", return_value=True)
+    assert "efs.12345" == watchdog.get_file_safe_mountpoint(_mount("/.efs"))
+
+
+def test_macos_hidden_directory_no_port(mocker):
+    """Combines the fix with the macOS no-port path: just 'efs'."""
+    mocker.patch("watchdog.check_if_running_on_macos", return_value=True)
+    assert "efs" == watchdog.get_file_safe_mountpoint(_mount("/.efs", NO_PORT_OPTIONS))


### PR DESCRIPTION
Description of changes:

- Fix channel init deadline establishment
- Update STS endpoint resolution
- Add RHEL10 support to efs-utils
