### PR TITLE
ci: Remove ubuntu-latest test until Ubuntu 26.04 support is added

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,9 +255,6 @@ workflows:
           name: python3_14
           image: python:3.14.3
       - build-deb-package:
-          name: ubuntu-latest
-          image: ubuntu:latest
-      - build-deb-package:
           name: ubuntu18
           image: ubuntu:18.04
       - build-deb-package:


### PR DESCRIPTION
Remove unsupported ubuntu 26.04 version in circle ci test.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
