### PR TITLE
Add auto-tag GitHub release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,93 @@
+name: Auto-tag GitHub Release
+
+# Automatically creates a git tag and GitHub release when the version in
+# config.ini changes on the main branch (i.e. after a release PR is merged).
+#
+# The version in config.ini is the source of truth. On every push to master the
+# workflow reads that version and, if a matching tag does not already exist,
+# creates tag `v<version>` at the pushed commit and publishes a GitHub release
+# whose body links to the manually-maintained CHANGELOG-<major>.x.md. Ordinary
+# (non-version-bump) merges are no-ops because the tag already exists.
+
+on:
+  push:
+    branches:
+      - master
+  # Allow manual re-runs against the current master HEAD if a release was missed.
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from config.ini
+        id: version
+        run: |
+          set -euo pipefail
+          RAW_VERSION="$(grep -oE '^version=[0-9]+\.[0-9]+\.[0-9]+' config.ini | head -n1 | cut -d= -f2)"
+          if [ -z "${RAW_VERSION}" ]; then
+            echo "::error::Could not parse a semantic version (X.Y.Z) from config.ini"
+            exit 1
+          fi
+          TAG="v${RAW_VERSION}"
+          MAJOR="${RAW_VERSION%%.*}"
+          echo "version=${RAW_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
+          echo "changelog=CHANGELOG-${MAJOR}.x.md" >> "${GITHUB_OUTPUT}"
+          echo "Parsed version=${RAW_VERSION}, tag=${TAG}, changelog=CHANGELOG-${MAJOR}.x.md"
+
+      - name: Check version against latest release
+        id: check
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # Highest existing semver tag on origin (strip refs/tags/ and the v
+          # prefix); empty if the repo has no release tags yet.
+          LATEST="$(git ls-remote --tags --refs origin 'v*' \
+            | sed -E 's#.*refs/tags/v##' \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sort -V | tail -n1 || true)"
+
+          if [ -z "${LATEST}" ]; then
+            echo "release=true" >> "${GITHUB_OUTPUT}"
+            echo "No existing release tags; proceeding with ${TAG}."
+          elif [ "${VERSION}" = "${LATEST}" ]; then
+            echo "release=false" >> "${GITHUB_OUTPUT}"
+            echo "Version ${VERSION} already released (tag ${TAG}); nothing to do."
+          elif [ "$(printf '%s\n%s\n' "${LATEST}" "${VERSION}" | sort -V | tail -n1)" = "${VERSION}" ]; then
+            echo "release=true" >> "${GITHUB_OUTPUT}"
+            echo "Version ${VERSION} is newer than latest release ${LATEST}; proceeding."
+          else
+            echo "::error::config.ini version ${VERSION} is OLDER than latest release ${LATEST}; refusing to release a regression."
+            exit 1
+          fi
+
+      - name: Create tag and GitHub release
+        if: steps.check.outputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+          CHANGELOG: ${{ steps.version.outputs.changelog }}
+        run: |
+          set -euo pipefail
+          # The changelog is maintained manually; the release body just links to it.
+          # gh release create creates and pushes the tag at --target implicitly.
+          gh release create "${TAG}" \
+            --target "${GITHUB_SHA}" \
+            --title "${TAG}" --notes-file - <<EOF
+          Amazon efs-utils
+
+          ## CHANGELOG
+          See [CHANGELOG](https://github.com/${GITHUB_REPOSITORY}/blob/master/${CHANGELOG}) for full list of changes
+          EOF
+          echo "Created release and tag ${TAG} at ${GITHUB_SHA}"


### PR DESCRIPTION
Testing: 
```
dev-dsk-maguirza-1d-b3615266 %   echo "--- Tags ---";     gh api repos/zmaguire/efs-utils/tags --jq '.[].name'

--- Tags ---

(26-07-07 18:38:56) <0> [~/ws/EFS-82338/efs-utils]  
dev-dsk-maguirza-1d-b3615266 %   echo "--- Releases ---"; gh release list --repo zmaguire/efs-utils

--- Releases ---
no releases found

(26-07-07 18:38:58) <0> [~/ws/EFS-82338/efs-utils]  
dev-dsk-maguirza-1d-b3615266 % git push --force-with-lease origin master
Enumerating objects: 8, done.
Counting objects: 100% (8/8), done.
Delta compression using up to 8 threads
Compressing objects: 100% (5/5), done.
Writing objects: 100% (5/5), 1.90 KiB | 1.90 MiB/s, done.
Total 5 (delta 1), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (1/1), completed with 1 local object.
To https://github.com/zmaguire/efs-utils.git
 + 4ee3071...6807230 master -> master (forced update)

(26-07-07 18:39:05) <0> [~/ws/EFS-82338/efs-utils]  
dev-dsk-maguirza-1d-b3615266 %   gh run watch --repo zmaguire/efs-utils \
    $(gh run list --repo zmaguire/efs-utils --workflow "Auto-tag GitHub Release" --limit 1 --json databaseId --jq '.[0].databaseId')

✓ master Auto-tag GitHub Release · 28889937031
Triggered via push less than a minute ago

JOBS
✓ release in 9s (ID 85699686343)
  ✓ Set up job
  ✓ Checkout
  ✓ Extract version from config.ini
  ✓ Check version against latest release
  ✓ Create tag and GitHub release
  ✓ Post Checkout
  ✓ Complete job

✓ Run Auto-tag GitHub Release (28889937031) completed with 'success'

(26-07-07 18:39:24) <0> [~/ws/EFS-82338/efs-utils]  
dev-dsk-maguirza-1d-b3615266 %   RUN=$(gh run list --repo zmaguire/efs-utils --workflow "Auto-tag GitHub Release" --limit 1 --json databaseId --jq '.[0].databaseId')


(26-07-07 18:39:28) <0> [~/ws/EFS-82338/efs-utils]  
dev-dsk-maguirza-1d-b3615266 %   gh run view "$RUN" --repo zmaguire/efs-utils --log | grep -iE "Parsed version|does not exist|Created release and tag"

release	Extract version from config.ini	2026-07-07T18:39:14.7731026Z echo "Parsed version=${RAW_VERSION}, tag=${TAG}, changelog=CHANGELOG-${MAJOR}.x.md"
release	Extract version from config.ini	2026-07-07T18:39:14.8030725Z Parsed version=3.1.3, tag=v3.1.3, changelog=CHANGELOG-3.x.md
release	Create tag and GitHub release	2026-07-07T18:39:15.1956371Z echo "Created release and tag ${TAG} at ${GITHUB_SHA}"
release	Create tag and GitHub release	2026-07-07T18:39:17.8351371Z Created release and tag v3.1.3 at 680723041327e183229e4627e0fd0a4514329551

(26-07-07 18:39:33) <0> [~/ws/EFS-82338/efs-utils]  
dev-dsk-maguirza-1d-b3615266 %   echo "--- Tags ---";     gh api repos/zmaguire/efs-utils/tags --jq '.[].name'

--- Tags ---
v3.1.3

(26-07-07 18:39:37) <0> [~/ws/EFS-82338/efs-utils]  
dev-dsk-maguirza-1d-b3615266 %   echo "--- Release body ---"; gh release view v3.1.3 --repo zmaguire/efs-utils

--- Release body ---
v3.1.3
github-actions[bot] released this less than a minute ago

  Amazon efs-utils                                                                                                    
                                                                                                                      
  ## CHANGELOG                                                                                                        
                                                                                                                      
  See CHANGELOG https://github.com/zmaguire/efs-utils/blob/master/CHANGELOG-3.x.md for full list of changes           


View on GitHub: https://github.com/zmaguire/efs-utils/releases/tag/v3.1.3

(26-07-07 18:39:40) <0> [~/ws/EFS-82338/efs-utils]  
dev-dsk-maguirza-1d-b3615266 %   echo "--- Tag commit (should == your pushed HEAD) ---"

--- Tag commit (should == your pushed HEAD) ---

(26-07-07 18:39:43) <0> [~/ws/EFS-82338/efs-utils]  
dev-dsk-maguirza-1d-b3615266 %   git ls-remote --tags origin v3.1.3

680723041327e183229e4627e0fd0a4514329551	refs/tags/v3.1.3

(26-07-07 18:39:46) <0> [~/ws/EFS-82338/efs-utils]  
dev-dsk-maguirza-1d-b3615266 %   git rev-parse HEAD

680723041327e183229e4627e0fd0a4514329551

(26-07-07 18:39:48) <0> [~/ws/EFS-82338/efs-utils]  
dev-dsk-maguirza-1d-b3615266 %   git commit --allow-empty -m "Idempotency test: no version change, expect no-op"

[master a9f43a1] Idempotency test: no version change, expect no-op

(26-07-07 18:39:59) <0> [~/ws/EFS-82338/efs-utils]  
dev-dsk-maguirza-1d-b3615266 %   git push origin master
dev-dsk-maguirza-1d-b3615266 %   gh run list --repo zmaguire/efs-utils --workflow "Auto-tag GitHub Release" --limit 5 \
    --json databaseId,headSha,status,conclusion,createdAt \
    --jq '.[] | "\(.databaseId)  \(.headSha[0:7])  \(.status)/\(.conclusion)  \(.createdAt)"'

28889995757  a9f43a1  completed/success  2026-07-07T18:40:07Z
28889937031  6807230  completed/success  2026-07-07T18:39:07Z
28889754151  4ee3071  completed/success  2026-07-07T18:36:01Z
28887761482  a060df7  completed/success  2026-07-07T18:02:24Z
28887587357  e2e447f  completed/success  2026-07-07T17:59:32Z

(26-07-07 18:41:28) <0> [~/ws/EFS-82338/efs-utils]  
dev-dsk-maguirza-1d-b3615266 % RUN2=28889995757                                                                        

(26-07-07 18:41:57) <0> [~/ws/EFS-82338/efs-utils]  
dev-dsk-maguirza-1d-b3615266 %   gh run view "$RUN2" --repo zmaguire/efs-utils --log | grep -iE "already exists|nothing to do"

release	Check version against latest release	2026-07-07T18:40:13.8076261Z   echo "Version ${VERSION} already released (tag ${TAG}); nothing to do."
release	Check version against latest release	2026-07-07T18:40:14.0990675Z Version 3.1.3 already released (tag v3.1.3); nothing to do.

(26-07-07 18:42:03) <0> [~/ws/EFS-82338/efs-utils]  
dev-dsk-maguirza-1d-b3615266 % sed -i 's/^version=3.1.3/version=3.1.2/' config.ini

(26-07-07 18:42:25) <0> [~/ws/EFS-82338/efs-utils]  
dev-dsk-maguirza-1d-b3615266 %   grep '^version=' config.ini                       # confirm now 3.1.2

config.ini:version=3.1.2
grep: #: No such file or directory
grep: confirm: No such file or directory
grep: now: No such file or directory
grep: 3.1.2: No such file or directory

(26-07-07 18:42:27) <2> [~/ws/EFS-82338/efs-utils]  
dev-dsk-maguirza-1d-b3615266 % git commit -am "Downgrade test: expect regression guard to fail (will revert)"

[master f7664e8] Downgrade test: expect regression guard to fail (will revert)
 1 file changed, 1 insertion(+), 1 deletion(-)

(26-07-07 18:42:32) <0> [~/ws/EFS-82338/efs-utils]  
dev-dsk-maguirza-1d-b3615266 % git push origin master
Enumerating objects: 5, done.
Counting objects: 100% (5/5), done.
Delta compression using up to 8 threads
Compressing objects: 100% (3/3), done.
Writing objects: 100% (3/3), 341 bytes | 341.00 KiB/s, done.
Total 3 (delta 2), reused 0 (delta 0), pack-reused 0 (from 0)
remote: Resolving deltas: 100% (2/2), completed with 2 local objects.
To https://github.com/zmaguire/efs-utils.git
   a9f43a1..f7664e8  master -> master

(26-07-07 18:42:36) <0> [~/ws/EFS-82338/efs-utils]  
dev-dsk-maguirza-1d-b3615266 %   gh run list --repo zmaguire/efs-utils --workflow "Auto-tag GitHub Release" --limit 5 \
    --json databaseId,headSha,status,conclusion,createdAt \
    --jq '.[] | "\(.databaseId)  \(.headSha[0:7])  \(.status)/\(.conclusion)  \(.createdAt)"'

28890146644  f7664e8  completed/failure  2026-07-07T18:42:38Z
28889995757  a9f43a1  completed/success  2026-07-07T18:40:07Z
28889937031  6807230  completed/success  2026-07-07T18:39:07Z
28889754151  4ee3071  completed/success  2026-07-07T18:36:01Z
28887761482  a060df7  completed/success  2026-07-07T18:02:24Z

(26-07-07 18:42:54) <0> [~/ws/EFS-82338/efs-utils]  
dev-dsk-maguirza-1d-b3615266 % DOWN="28890146644"

(26-07-07 18:43:07) <0> [~/ws/EFS-82338/efs-utils]  
dev-dsk-maguirza-1d-b3615266 %   gh run view "$DOWN" --repo zmaguire/efs-utils --log | grep -iE "OLDER than latest|refusing to release"

release	Check version against latest release	2026-07-07T18:42:48.1194528Z   echo "::error::config.ini version ${VERSION} isOLDER than latest release ${LATEST}; refusing to release a regression."
release	Check version against latest release	2026-07-07T18:42:48.3053848Z ##[error]config.ini version 3.1.2 is OLDER than latest release 3.1.3; refusing to release a regression.

(26-07-07 18:43:14) <0> [~/ws/EFS-82338/efs-utils]  
dev-dsk-maguirza-1d-b3615266 % gh api repos/zmaguire/efs-utils/tags --jq '.[].name'
v3.1.3

(26-07-07 18:43:26) <0> [~/ws/EFS-82338/efs-utils]  
dev-dsk-maguirza-1d-b3615266 %   gh release list --repo zmaguire/efs-utils

TITLE   TYPE    TAG NAME  PUBLISHED          
v3.1.3  Latest  v3.1.3    about 4 minutes ago
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
