### PR TITLE
watchdog: fix FileNotFoundError crash on stunnel.pid under high mount churn

### DIFF
--- a/src/watchdog/__init__.py
+++ b/src/watchdog/__init__.py
@@ -891,10 +891,15 @@ def get_pid_in_state_dir(state_file, state_file_dir):
     state_dir_pid_path = os.path.join(
         state_file_dir, state_file + "+", STUNNEL_PID_FILE
     )
-    if os.path.exists(state_dir_pid_path):
+    # Open directly rather than checking os.path.exists() first: under high mount
+    # churn the mount's own unmount teardown can delete this pid file between the
+    # existence check and the open, and the resulting FileNotFoundError would crash
+    # the watchdog. Letting open() answer "does it exist" atomically avoids that race.
+    try:
         with open(state_dir_pid_path) as f:
             return f.read()
-    return None
+    except FileNotFoundError:
+        return None
 
 
 def is_mount_stunnel_proc_running(state_pid, state_file, state_file_dir):

--- a/test/watchdog_test/test_send_signal_to_stunnel_processes.py
+++ b/test/watchdog_test/test_send_signal_to_stunnel_processes.py
@@ -82,6 +82,19 @@ def test_pid_file_not_in_state_dir(tmpdir):
     assert watchdog.get_pid_in_state_dir(STATE_FILE, str(tmpdir)) is None
 
 
+def test_get_pid_in_state_dir_deleted_before_open(mocker, tmpdir):
+    # Simulate the mount's unmount teardown deleting the pid file between the
+    # existence check and open() under high churn. get_pid_in_state_dir must
+    # return None rather than let FileNotFoundError crash the watchdog.
+    mount_dir = create_dir(tmpdir, MOUNT_STATE_DIR)
+    pid_dir, pid_file, abs_pid_file = create_pid_file(mount_dir, PID)
+    assert os.path.exists(abs_pid_file)
+
+    mocker.patch("watchdog.open", side_effect=FileNotFoundError)
+
+    assert watchdog.get_pid_in_state_dir(STATE_FILE, str(tmpdir)) is None
+
+
 def test_is_mount_stunnel_proc_running_pid_empty(tmpdir):
     assert False == watchdog.is_mount_stunnel_proc_running(None, STATE_FILE, tmpdir)
 


### PR DESCRIPTION
## Summary

Fixes a check-then-use (TOCTOU) race in `get_pid_in_state_dir` that crashes `amazon-efs-mount-watchdog` under high mount churn. Reported in #361.

`get_pid_in_state_dir` did `os.path.exists()` and then `open()` in two steps:

```python
if os.path.exists(state_dir_pid_path):
    with open(state_dir_pid_path) as f:
        return f.read()
return None
```

On a node running many short-lived pods that mount/unmount EFS access points, a mount's own unmount teardown deletes `…mount.NNNNN+/stunnel.pid` in the window between the `exists()` check and the `open()`. The `open()` then raises `FileNotFoundError` and the single-threaded watchdog exits. It is reached from inside the cleanup path (`clean_up_mount_state` → `cleanup_mount_state_if_stunnel_not_running` → `is_mount_stunnel_proc_running` → `get_pid_in_state_dir`), and under sustained churn it crash-loops, so tunnel reconciliation stops.

## Fix

Drop the pre-check and open directly, treating `FileNotFoundError` as "no pid file" — the same `None` return the callers already handle (`is_mount_stunnel_proc_running` assumes the tunnel is still running on a falsy return). This mirrors the sibling `os.remove()` in the cleanup block, which already tolerates `ENOENT`. Because the OS answers "does it exist" atomically as part of the open, there is no longer a gap for a concurrent delete to slip through.

## Testing

Added `test_get_pid_in_state_dir_deleted_before_open`, which simulates the pid file being deleted between the existence check and the open. It fails against the current code (`FileNotFoundError` propagates) and passes with this change. Existing `get_pid_in_state_dir` tests still pass.