### PR TITLE
Add GitHub Actions CI workflow (port of CircleCI matrix)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,320 @@
+# Continuous integration for efs-utils.
+#
+# Runs the Python unit test suite across the supported interpreter versions and
+# builds + installs the DEB, RPM, and SUSE RPM packages across the supported
+# distributions, verifying each install with `mount.efs --version`.
+#
+# Jobs run inside the per-matrix container image (the same images the previous
+# CI system used), so the apt/yum/zypper toolchain setup below runs against the
+# target distribution exactly as it would on that distribution.
+#
+# NOTE on `old_glibc` legs (glibc < 2.28): GitHub's runner now executes all
+# JavaScript actions on Node 24, which requires glibc >= 2.28. Distros older
+# than that (ubuntu 18.04, amazonlinux:2, opensuse leap 15.1/15.2) therefore
+# cannot run actions/checkout or actions/setup-go at all. Those legs perform a
+# manual `git` checkout and a manual Go install with plain shell steps (no JS
+# actions). SUSE images additionally ship without `tar`, which the runner needs
+# to unpack JS actions, so the modern SUSE legs install it before checkout.
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: python3_10
+            image: python:3.10.13
+          - name: python3_11
+            image: python:3.11.9
+          - name: python3_12
+            image: python:3.12.4
+          - name: python3_13
+            image: python:3.13.12
+          - name: python3_14
+            image: python:3.14.3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Python dependencies in a virtual env
+        run: |
+          pip install --upgrade pip
+          pip install virtualenv
+          virtualenv -p $(which python) ~/efs-utils-virtualenv
+          . ~/efs-utils-virtualenv/bin/activate
+          pip install -r requirements.txt
+      - name: Run all tests
+        run: |
+          . ~/efs-utils-virtualenv/bin/activate
+          make test
+      - name: Store artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-${{ matrix.name }}
+          path: build
+          if-no-files-found: ignore
+
+  build-deb-package:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubuntu18
+            image: ubuntu:18.04
+            old_glibc: true
+          - name: ubuntu20
+            image: ubuntu:20.04
+          - name: ubuntu22
+            image: ubuntu:22.04
+          - name: ubuntu24
+            image: ubuntu:24.04
+          - name: debian11
+            image: debian:bullseye
+          - name: debian12
+            image: debian:bookworm
+          - name: debian13
+            image: debian:trixie
+    steps:
+      - name: Repo update
+        run: |
+          apt-get update
+      - name: Install curl
+        run: |
+          apt-get -y install curl
+      # old_glibc: no JS actions (Node 24 needs glibc >= 2.28); checkout by hand.
+      - name: Manual checkout (old glibc)
+        if: ${{ matrix.old_glibc }}
+        run: |
+          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends git ca-certificates tar
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git init -q .
+          git remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"
+          git fetch --no-tags --depth 1 origin "$GITHUB_SHA"
+          git checkout -q FETCH_HEAD
+      - name: Install latest Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          . "$HOME/.cargo/env"
+      # Install Go by hand on every leg to mirror the CircleCI wget|tar approach
+      # (and because actions/setup-go can corrupt the container exec PATH).
+      - name: Install golang (manual)
+        run: |
+          GO_TGZ="$(curl -sSL https://go.dev/VERSION?m=text | head -n1).linux-amd64.tar.gz"
+          curl -sSL "https://go.dev/dl/${GO_TGZ}" -o /tmp/go.tgz
+          rm -rf /usr/local/go && tar -C /usr/local -xzf /tmp/go.tgz
+      - name: Install dependencies
+        run: |
+          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends tzdata
+          if grep -q 'Ubuntu 20.04' /etc/os-release 2>/dev/null; then
+            apt-get -y install binutils git rustc cargo pkg-config libssl-dev gettext cmake gcc-10 g++-10
+            update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100
+            update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
+          elif grep -q 'trixie' /etc/os-release 2>/dev/null; then
+            apt-get -y install binutils git rustc cargo pkg-config libssl-dev gettext cmake gcc-13 g++-13
+          else
+            apt-get -y install binutils git rustc cargo pkg-config libssl-dev gettext cmake gcc g++
+          fi
+      - name: Add local build repo as safe git directory
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - name: Checkout
+        if: ${{ !matrix.old_glibc }}
+        uses: actions/checkout@v4
+      - name: Build DEB
+        run: |
+          . "$HOME/.cargo/env"
+          export PATH=$PATH:/usr/local/go/bin
+          if grep -q 'trixie' /etc/os-release 2>/dev/null; then
+            export CC=gcc-13
+            export CXX=g++-13
+          fi
+          rustc --version
+          cargo --version
+          go version
+          cmake --version
+          ./build-deb.sh
+      - name: Install package
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get -y install --fix-missing ./build/amazon-efs-utils*deb
+      - name: Check installed successfully
+        run: |
+          mount.efs --version
+
+  build-rpm-package:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: rocky8
+            image: rockylinux/rockylinux:8
+          - name: amazon-linux-latest
+            image: amazonlinux:latest
+          - name: amazon-linux-2
+            image: amazonlinux:2
+            old_glibc: true
+    steps:
+      # AL2023 (amazonlinux:latest) ships without tar, which the runner needs to
+      # unpack JS actions; install it before the checkout action runs.
+      - name: Prepare tar for actions (modern)
+        if: ${{ !matrix.old_glibc }}
+        run: |
+          yum -y install tar gzip
+      # old_glibc: no JS actions (Node 24 needs glibc >= 2.28); checkout by hand.
+      - name: Manual checkout (old glibc)
+        if: ${{ matrix.old_glibc }}
+        run: |
+          yum -y install git tar
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git init -q .
+          git remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"
+          git fetch --no-tags --depth 1 origin "$GITHUB_SHA"
+          git checkout -q FETCH_HEAD
+      - name: Checkout
+        if: ${{ !matrix.old_glibc }}
+        uses: actions/checkout@v4
+      - name: Install latest Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      # Install Go by hand on every leg to mirror the CircleCI wget|tar approach
+      # (and because actions/setup-go can corrupt the container exec PATH).
+      - name: Install golang (manual)
+        run: |
+          GO_TGZ="$(curl -sSL https://go.dev/VERSION?m=text | head -n1).linux-amd64.tar.gz"
+          curl -sSL "https://go.dev/dl/${GO_TGZ}" -o /tmp/go.tgz
+          rm -rf /usr/local/go && tar -C /usr/local -xzf /tmp/go.tgz
+      - name: Install dependencies
+        run: |
+          if grep -q '^ID="amzn"' /etc/os-release && grep -q '^VERSION_ID="2"' /etc/os-release 2>/dev/null; then
+            yum -y install rpm-build make systemd rust cargo openssl-devel cmake3 gcc gcc-c++ perl binutils
+            if [ ! -e /usr/bin/cmake ]; then
+              ln -sf /usr/bin/cmake3 /usr/bin/cmake
+            fi
+          else
+            yum -y install rpm-build make systemd rust cargo openssl-devel cmake gcc gcc-c++ perl binutils
+          fi
+      - name: Build RPM
+        run: |
+          . "$HOME/.cargo/env"
+          export PATH=$PATH:/usr/local/go/bin
+          rustc --version
+          go version
+          cmake --version
+          make rpm
+      - name: Install package
+        run: |
+          yum -y install build/amazon-efs-utils*rpm
+      - name: Check installed successfully
+        run: |
+          mount.efs --version
+      - name: Check changelog
+        run: |
+          rpm -q --changelog amazon-efs-utils
+
+  build-suse-rpm-package:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.image }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: opensuse-leap15.1
+            image: opensuse/leap:15.1
+            old_glibc: true
+          - name: opensuse-leap15.2
+            image: opensuse/leap:15.2
+            old_glibc: true
+          - name: opensuse-leap15.3
+            image: opensuse/leap:15.3
+          - name: opensuse-leap15.4
+            image: opensuse/leap:15.4
+          - name: opensuse-leap-latest
+            image: opensuse/leap:latest
+          - name: opensuse-tumbleweed
+            image: opensuse/tumbleweed
+    steps:
+      # SUSE images ship without tar, which the runner needs to unpack JS
+      # actions; install it before the checkout action runs (modern legs only).
+      - name: Prepare zypper + tar for actions (modern)
+        if: ${{ !matrix.old_glibc }}
+        run: |
+          zypper --non-interactive --gpg-auto-import-keys refresh || true
+          zypper --non-interactive install -y tar gzip
+      - name: Checkout
+        if: ${{ !matrix.old_glibc }}
+        uses: actions/checkout@v4
+      # old_glibc: no JS actions (Node 24 needs glibc >= 2.28); checkout by hand.
+      - name: Manual checkout (old glibc)
+        if: ${{ matrix.old_glibc }}
+        run: |
+          zypper --non-interactive install -y git tar curl gzip
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          git init -q .
+          git remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY"
+          git fetch --no-tags --depth 1 origin "$GITHUB_SHA"
+          git checkout -q FETCH_HEAD
+      - name: Refresh source
+        run: |
+          zypper refresh
+      - name: Install curl
+        run: |
+          zypper install -y curl
+      - name: Install latest Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      # All SUSE legs install Go by hand: actions/setup-go corrupts the container
+      # exec PATH on the newer/rolling openSUSE images (leap 15.3/15.4/latest,
+      # tumbleweed), breaking the next step with `exec: "sh": not found`. The
+      # manual tarball install is what the leap15.1/15.2 legs already use.
+      - name: Install golang (manual)
+        run: |
+          GO_TGZ="$(curl -sSL https://go.dev/VERSION?m=text | head -n1).linux-amd64.tar.gz"
+          curl -sSL "https://go.dev/dl/${GO_TGZ}" -o /tmp/go.tgz
+          rm -rf /usr/local/go && tar -C /usr/local -xzf /tmp/go.tgz
+      - name: Install dependencies
+        run: |
+          zypper install -y --force-resolution rpm-build
+          # Leap 16's default gcc (14/15) breaks the aws-lc FIPS delocate step;
+          # pin gcc13 there too, matching the Tumbleweed leg that builds cleanly.
+          if grep -qE 'Tumbleweed|VERSION_ID="16' /etc/os-release 2>/dev/null; then
+            zypper install -y make systemd rust cargo openssl-devel cmake gcc13 gcc13-c++ perl binutils
+          else
+            zypper install -y make systemd rust cargo openssl-devel cmake gcc gcc-c++ perl binutils
+          fi
+      - name: Build RPM
+        run: |
+          . "$HOME/.cargo/env"
+          export PATH=$PATH:/usr/local/go/bin
+          if grep -qE 'Tumbleweed|VERSION_ID="16' /etc/os-release 2>/dev/null; then
+            export CC=gcc-13
+            export CXX=g++-13
+          fi
+          rustc --version
+          go version
+          cmake --version
+          make rpm
+      - name: Install package
+        run: |
+          zypper --no-gpg-checks install -y build/amazon-efs-utils*rpm
+      - name: Check installed successfully
+        run: |
+          mount.efs --version
+      - name: Check changelog
+        run: |
+          rpm -q --changelog amazon-efs-utils


### PR DESCRIPTION
Port .circleci/config.yml to .github/workflows/ci.yaml: Python unit tests (3.10-3.14) plus DEB/RPM/SUSE build+install smoke tests across the full distro matrix.

Distro-compatibility fixes vs a naive port:
- dash-shell: use POSIX '.' instead of 'source'
- old-glibc legs (ubuntu18/AL2/leap15.1-15.2): manual git checkout + manual Go install (Node24 JS actions need glibc>=2.28)
- install tar/gzip before checkout on SUSE and AL2023 (runner unpacks JS actions with tar)
- drop 'git -c protocol.version=2' (git 2.17 on bionic rejects it)
- manual Go install on all legs (actions/setup-go corrupts container exec PATH on newer openSUSE)
- pin gcc13 on Leap 16 (default gcc breaks the aws-lc FIPS delocate step)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
